### PR TITLE
fix: return correct fitting losses

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,6 +24,7 @@ jobs:
           - [ubuntu-latest, musllinux_x86_64, ""]
 
           # the macos-14 runner uses an Apple silicon chip, while the macos-13 runner uses an Intel chip
+          - [macos-12, macosx_x86_64, ""]
           - [macos-13, macosx_x86_64, ""]
           - [macos-14, macosx_arm64, accelerate]
           - [macos-15, macosx_arm64, accelerate]

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -373,6 +373,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     if max_circles is not None:
         sorting_indices = np.argsort(fitting_losses)
         detected_circles = detected_circles[sorting_indices]
+        fitting_losses = fitting_losses[sorting_indices]
         detected_circles = detected_circles[:max_circles]
         fitting_losses = fitting_losses[:max_circles]
 

--- a/test/test_circle_detection.py
+++ b/test/test_circle_detection.py
@@ -163,7 +163,7 @@ class TestCircleDetection:
         for circle in detected_circles:
             residuals = (np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth
             expected_loss = -1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2)
-            expected_fitting_losses.append(expected_loss.sum())
+            expected_fitting_losses.append(expected_loss.mean())
 
         assert (np.abs(original_circles - detected_circles) < 0.03).all()
         np.testing.assert_almost_equal(expected_fitting_losses, fitting_losses, decimal=5)

--- a/test/test_circle_detection.py
+++ b/test/test_circle_detection.py
@@ -142,8 +142,9 @@ class TestCircleDetection:
         xy = self._generate_circle_points(
             original_circles, min_points=100, max_points=100, variance=np.array([0, 0.05])
         )
+        bandwidth = 0.05
 
-        detected_circles, fitting_losses = detect_circles(xy, bandwidth=0.05, max_circles=1)
+        detected_circles, fitting_losses = detect_circles(xy, bandwidth=bandwidth, max_circles=1)
 
         assert len(detected_circles) == 1
         assert len(fitting_losses) == 1
@@ -152,12 +153,20 @@ class TestCircleDetection:
         np.testing.assert_array_equal(original_circles[0], detected_circles[0])
 
         detected_circles, fitting_losses = detect_circles(
-            xy, bandwidth=0.05, max_circles=2, non_maximum_suppression=True
+            xy, bandwidth=bandwidth, max_circles=2, non_maximum_suppression=True
         )
 
         assert len(detected_circles) == 2
         assert len(fitting_losses) == 2
+
+        expected_fitting_losses = []
+        for circle in detected_circles:
+            residuals = (np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth
+            expected_loss = -1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2)
+            expected_fitting_losses.append(expected_loss.sum())
+
         assert (np.abs(original_circles - detected_circles) < 0.03).all()
+        np.testing.assert_almost_equal(expected_fitting_losses, fitting_losses, decimal=5)
 
     def test_several_noisy_circles(self):
         original_circles = self._generate_circles(


### PR DESCRIPTION
This pull request fixes a bug in the `detect_circles` method: If the `max_circles` option is enabled, the detected circles are sorted by their fitting losses, and the circles with the lowest fitting losses are returned. Previously, the fitting losses themselves were not sorted, so the fitting losses returned by the `detect_circles` method were incorrect when the `max_circles` option was enabled.