### PR TITLE
ci: remove build for macOS 12

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -24,7 +24,6 @@ jobs:
           - [ubuntu-latest, musllinux_x86_64, ""]
 
           # the macos-14 runner uses an Apple silicon chip, while the macos-13 runner uses an Intel chip
-          - [macos-12, macosx_x86_64, ""]
           - [macos-13, macosx_x86_64, ""]
           - [macos-14, macosx_arm64, accelerate]
           - [macos-15, macosx_arm64, accelerate]


### PR DESCRIPTION
This pull request removes the build for macOS 12 from the release pipeline, which was accidentally added in #5. 