### PR TITLE
feat: batch processing support

### DIFF
--- a/csrc/include/CircleDetection/circle_detection.h
+++ b/csrc/include/CircleDetection/circle_detection.h
@@ -3,14 +3,15 @@
 #include <Eigen/Dense>
 #include <cmath>
 #include <iostream>
+#include <tuple>
 #include <vector>
 
+namespace {
+
+using namespace Eigen;
 using ArrayXb = Eigen::Array<bool, Eigen::Dynamic, 1>;
 using ArrayXl = Eigen::Array<long, Eigen::Dynamic, 1>;
 
-using namespace Eigen;
-
-namespace {
 double loss_fn_scalar(double scaled_residual) {
   const double SQRT_2_PI = 2.5066282746310002;
   return -exp(-(scaled_residual * scaled_residual) / 2) / SQRT_2_PI;
@@ -23,215 +24,260 @@ double loss_fn_derivative_1_scalar(double scaled_residual) {
 double loss_fn_derivative_2_scalar(double scaled_residual) {
   return loss_fn_scalar(scaled_residual) * (scaled_residual * scaled_residual - 1);
 }
-
 }  // namespace
 
 namespace CircleDetection {
-std::tuple<ArrayX3d, ArrayXd> detect_circles(ArrayX2d xy, double bandwidth, double min_start_x, double max_start_x,
-                                             int n_start_x, double min_start_y, double max_start_y, int n_start_y,
-                                             double min_start_radius, double max_start_radius, int n_start_radius,
-                                             double break_min_x, double break_max_x, double break_min_y,
-                                             double break_max_y, double break_min_radius, double break_max_radius,
-                                             double break_min_change = 1e-5, int max_iterations = 1000,
-                                             double acceleration_factor = 1.6, double armijo_attenuation_factor = 0.7,
-                                             double armijo_min_decrease_percentage = 0.5, double min_step_size = 1e-20,
-                                             double min_fitting_score = 1e-6) {
-  if (min_start_x == max_start_x) {
-    n_start_x = 1;
-  }
+std::tuple<std::vector<ArrayX3d>, std::vector<ArrayXd>> detect_circles(
+    ArrayX2d xy, std::vector<std::vector<int64_t>> batch_indices, double bandwidth, ArrayXd min_start_x,
+    ArrayXd max_start_x, int n_start_x, ArrayXd min_start_y, ArrayXd max_start_y, int n_start_y,
+    ArrayXd min_start_radius, ArrayXd max_start_radius, int n_start_radius, ArrayXd break_min_x, ArrayXd break_max_x,
+    ArrayXd break_min_y, ArrayXd break_max_y, ArrayXd break_min_radius, ArrayXd break_max_radius,
+    double break_min_change = 1e-5, int max_iterations = 1000, double acceleration_factor = 1.6,
+    double armijo_attenuation_factor = 0.7, double armijo_min_decrease_percentage = 0.5, double min_step_size = 1e-20,
+    double min_fitting_score = 1e-6) {
+  auto n_batches = batch_indices.size() > 0 ? batch_indices.size() : 1;
 
-  if (min_start_y == max_start_y) {
-    n_start_y = 1;
-  }
-
-  if (min_start_radius == max_start_radius) {
-    n_start_radius = 1;
-  }
-
-  ArrayXd start_radii = ArrayXd::LinSpaced(n_start_radius, min_start_radius, max_start_radius);
-  ArrayXd start_centers_x = ArrayXd::LinSpaced(n_start_x, min_start_x, max_start_x);
-  ArrayXd start_centers_y = ArrayXd::LinSpaced(n_start_y, min_start_y, max_start_y);
-
-  ArrayX3d fitted_circles = ArrayX3d::Constant(n_start_radius * n_start_x * n_start_y, 3, -1);
-  ArrayXb fitting_converged = ArrayXb::Zero(n_start_radius * n_start_x * n_start_y);
-  ArrayXd fitting_losses = ArrayXd::Constant(n_start_radius * n_start_x * n_start_y, 0);
+  ArrayXd start_radii(n_batches * n_start_radius);
+  ArrayXd start_centers_x(n_batches * n_start_x);
+  ArrayXd start_centers_y(n_batches * n_start_y);
 
 #pragma omp parallel for
-  for (int idx = 0; idx < n_start_radius * n_start_x * n_start_y; ++idx) {
-    auto idx_1 = idx / (n_start_x * n_start_y);
-    auto remainder = idx % (n_start_x * n_start_y);
-    auto idx_2 = remainder / n_start_y;
-    auto idx_3 = remainder % n_start_y;
+  for (int64_t i = 0; i < n_batches; ++i) {
+    start_radii.segment(i * n_start_radius, n_start_radius) =
+        ArrayXd::LinSpaced(n_start_radius, min_start_radius(i), max_start_radius(i));
+    start_centers_x.segment(i * n_start_x, n_start_x) = ArrayXd::LinSpaced(n_start_x, min_start_x(i), max_start_x(i));
+    start_centers_y.segment(i * n_start_y, n_start_y) = ArrayXd::LinSpaced(n_start_y, min_start_y(i), max_start_y(i));
+  }
 
-    auto start_radius = start_radii[idx_1];
-    auto radius = start_radius;
+  ArrayX3d fitted_circles = ArrayX3d::Constant(n_batches * n_start_radius * n_start_x * n_start_y, 3, -1);
+  ArrayXb fitting_converged = ArrayXb::Zero(n_batches * n_start_radius * n_start_x * n_start_y);
+  ArrayXd fitting_losses = ArrayXd::Constant(n_batches * n_start_radius * n_start_x * n_start_y, 0);
 
-    auto start_center_x = start_centers_x[idx_2];
-    auto start_center_y = start_centers_y[idx_3];
-    RowVector2d center(start_center_x, start_center_y);
+#pragma omp parallel
+#pragma omp single
+  for (int64_t idx_batch = 0; idx_batch < n_batches; ++idx_batch) {
+    for (int64_t idx_x = 0; idx_x < n_start_x; ++idx_x) {
+      for (int64_t idx_y = 0; idx_y < n_start_y; ++idx_y) {
+        for (int64_t idx_radius = 0; idx_radius < n_start_radius; ++idx_radius) {
+          if (min_start_x(idx_batch) == max_start_x(idx_batch) && idx_x > 0) {
+            continue;
+          }
+          if (min_start_y(idx_batch) == max_start_y(idx_batch) && idx_y > 0) {
+            continue;
+          }
+          if (min_start_radius(idx_batch) == max_start_radius(idx_batch) && idx_radius > 0) {
+            continue;
+          }
+          if (batch_indices.size() > 0 && batch_indices[idx_batch].size() < 3) {
+            continue;
+          }
 
-    double fitting_loss = 0;
-    double fitting_score = 0;
-    bool diverged = false;
+#pragma omp task
+          {
+            ArrayX2d current_xy;
+            if (n_batches > 1) {
+              current_xy = xy(batch_indices[idx_batch], Eigen::all);
+            } else {
+              current_xy = xy;
+            }
 
-    for (int iteration = 0; iteration < max_iterations; ++iteration) {
-      ArrayXd squared_dists_to_center = (xy.matrix().rowwise() - center).rowwise().squaredNorm().array();
-      ArrayXd dists_to_center = squared_dists_to_center.array().sqrt();
-      ArrayXd scaled_residuals = (dists_to_center - radius) / bandwidth;
-      fitting_loss = scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
+            auto start_radius = start_radii[idx_batch * n_start_radius + idx_radius];
+            auto radius = start_radius;
 
-      // first derivative of the outer term of the loss function
-      ArrayXd outer_derivative_1 = scaled_residuals.unaryExpr(&loss_fn_derivative_1_scalar);
+            auto start_center_x = start_centers_x[idx_batch * n_start_x + idx_x];
+            auto start_center_y = start_centers_y[idx_batch * n_start_y + idx_y];
+            RowVector2d center(start_center_x, start_center_y);
 
-      // second derivative of the outer term of the loss function
-      ArrayXd outer_derivative_2 = scaled_residuals.unaryExpr(&loss_fn_derivative_2_scalar);
+            double fitting_loss = 0;
+            double fitting_score = 0;
+            bool diverged = false;
 
-      // first derivative of the inner term of the loss function
-      // this array stores the derivatives dx and dy in different columns
-      ArrayX2d inner_derivative_1_x =
-          (-1 / (bandwidth * dists_to_center)).replicate(1, 2) * (xy.matrix().rowwise() - center).array();
-      double inner_derivative_1_r = -1 / bandwidth;
+            for (int iteration = 0; iteration < max_iterations; ++iteration) {
+              ArrayXd squared_dists_to_center =
+                  (current_xy.matrix().rowwise() - center).rowwise().squaredNorm().array();
+              ArrayXd dists_to_center = squared_dists_to_center.array().sqrt();
+              ArrayXd scaled_residuals = (dists_to_center - radius) / bandwidth;
+              fitting_loss = scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
 
-      // second derivative of the inner term of the loss function
-      // this array stores the derivatives dxdx and dydy in different columns
-      ArrayX2d inner_derivative_2_x_x = 1 / bandwidth *
-                                        (-1 / (squared_dists_to_center * dists_to_center).replicate(1, 2) *
-                                             (xy.matrix().rowwise() - center).array().square() +
-                                         1 / dists_to_center.replicate(1, 2));
-      // this array stores the derivatives dxdy and dydx in one column (both are identical)
-      ArrayXd inner_derivative_2_x_y = -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) *
-                                       (xy.col(0) - center[0]) * (xy.col(1) - center[1]);
+              // first derivative of the outer term of the loss function
+              ArrayXd outer_derivative_1 = scaled_residuals.unaryExpr(&loss_fn_derivative_1_scalar);
 
-      // first derivatives of the entire loss function with respect to the circle parameters
-      RowVector2d derivative_xy = (outer_derivative_1.replicate(1, 2) * inner_derivative_1_x).matrix().colwise().sum();
-      double derivative_r = (outer_derivative_1 * inner_derivative_1_r).matrix().sum();
-      Vector3d gradient(derivative_xy[0], derivative_xy[1], derivative_r);
+              // second derivative of the outer term of the loss function
+              ArrayXd outer_derivative_2 = scaled_residuals.unaryExpr(&loss_fn_derivative_2_scalar);
 
-      // second derivatives of the entire loss function with respect to the circle parameters
-      double derivative_x_x = ((outer_derivative_2 * inner_derivative_1_x.col(0).square()) +
-                               (outer_derivative_1 * inner_derivative_2_x_x.col(0)))
-                                  .matrix()
-                                  .sum();
-      double derivative_x_y = ((outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_x.col(0)) +
-                               (outer_derivative_1 * inner_derivative_2_x_y))
-                                  .matrix()
-                                  .sum();
-      double derivative_x_r = (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(0)).matrix().sum();
+              // first derivative of the inner term of the loss function
+              // this array stores the derivatives dx and dy in different columns
+              ArrayX2d inner_derivative_1_x = (-1 / (bandwidth * dists_to_center)).replicate(1, 2) *
+                                              (current_xy.matrix().rowwise() - center).array();
+              double inner_derivative_1_r = -1 / bandwidth;
 
-      double derivative_y_x = ((outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_x.col(1)) +
-                               (outer_derivative_1 * inner_derivative_2_x_y))
-                                  .matrix()
-                                  .sum();
-      double derivative_y_y = ((outer_derivative_2 * inner_derivative_1_x.col(1).square()) +
-                               (outer_derivative_1 * inner_derivative_2_x_x.col(1)))
-                                  .matrix()
-                                  .sum();
-      double derivative_y_r = (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(1)).matrix().sum();
+              // second derivative of the inner term of the loss function
+              // this array stores the derivatives dxdx and dydy in different columns
+              ArrayX2d inner_derivative_2_x_x = 1 / bandwidth *
+                                                (-1 / (squared_dists_to_center * dists_to_center).replicate(1, 2) *
+                                                     (current_xy.matrix().rowwise() - center).array().square() +
+                                                 1 / dists_to_center.replicate(1, 2));
+              // this array stores the derivatives dxdy and dydx in one column (both are identical)
+              ArrayXd inner_derivative_2_x_y = -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) *
+                                               (current_xy.col(0) - center[0]) * (current_xy.col(1) - center[1]);
 
-      double derivative_r_x = (outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_r).matrix().sum();
-      double derivative_r_y = (outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_r).matrix().sum();
-      double derivative_r_r = (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_r).matrix().sum();
+              // first derivatives of the entire loss function with respect to the circle parameters
+              RowVector2d derivative_xy =
+                  (outer_derivative_1.replicate(1, 2) * inner_derivative_1_x).matrix().colwise().sum();
+              double derivative_r = (outer_derivative_1 * inner_derivative_1_r).matrix().sum();
+              Vector3d gradient(derivative_xy[0], derivative_xy[1], derivative_r);
 
-      Matrix3d hessian(3, 3);
-      hessian << derivative_x_x, derivative_x_y, derivative_x_r, derivative_y_x, derivative_y_y, derivative_y_r,
-          derivative_r_x, derivative_r_y, derivative_r_r;
+              // second derivatives of the entire loss function with respect to the circle parameters
+              double derivative_x_x = ((outer_derivative_2 * inner_derivative_1_x.col(0).square()) +
+                                       (outer_derivative_1 * inner_derivative_2_x_x.col(0)))
+                                          .matrix()
+                                          .sum();
+              double derivative_x_y =
+                  ((outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_x.col(0)) +
+                   (outer_derivative_1 * inner_derivative_2_x_y))
+                      .matrix()
+                      .sum();
+              double derivative_x_r =
+                  (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(0)).matrix().sum();
 
-      double determinant_hessian = hessian.determinant();
+              double derivative_y_x =
+                  ((outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_x.col(1)) +
+                   (outer_derivative_1 * inner_derivative_2_x_y))
+                      .matrix()
+                      .sum();
+              double derivative_y_y = ((outer_derivative_2 * inner_derivative_1_x.col(1).square()) +
+                                       (outer_derivative_1 * inner_derivative_2_x_x.col(1)))
+                                          .matrix()
+                                          .sum();
+              double derivative_y_r =
+                  (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(1)).matrix().sum();
 
-      double determinant_hessian_submatrix = derivative_x_x * derivative_y_y - derivative_x_y * derivative_y_x;
+              double derivative_r_x =
+                  (outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_r).matrix().sum();
+              double derivative_r_y =
+                  (outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_r).matrix().sum();
+              double derivative_r_r = (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_r).matrix().sum();
 
-      double step_size = 1.0;
-      ArrayXd step_direction(3);
-      if ((determinant_hessian > 0) && (determinant_hessian_submatrix > 0)) {
-        step_direction = -1 * (hessian.inverse() * gradient).array();
-      } else {
-        step_direction = -1 * gradient;
+              Matrix3d hessian(3, 3);
+              hessian << derivative_x_x, derivative_x_y, derivative_x_r, derivative_y_x, derivative_y_y, derivative_y_r,
+                  derivative_r_x, derivative_r_y, derivative_r_r;
 
-        // step size acceleration
-        double next_step_size = 1.0;
-        auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
-        auto next_radius = radius + (next_step_size * step_direction[2]);
-        ArrayXd next_scaled_residuals =
-            ((xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
-        auto next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
-        auto previous_loss = fitting_loss;
+              double determinant_hessian = hessian.determinant();
 
-        while (next_loss < previous_loss) {
-          step_size = next_step_size;
-          fitting_score = -1 * next_loss;
-          previous_loss = next_loss;
-          next_step_size *= acceleration_factor;
+              double determinant_hessian_submatrix = derivative_x_x * derivative_y_y - derivative_x_y * derivative_y_x;
 
-          auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
-          auto next_radius = radius + (next_step_size * step_direction[2]);
-          ArrayXd next_scaled_residuals =
-              ((xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
-          next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
+              double step_size = 1.0;
+              ArrayXd step_direction(3);
+              if ((determinant_hessian > 0) && (determinant_hessian_submatrix > 0)) {
+                step_direction = -1 * (hessian.inverse() * gradient).array();
+              } else {
+                step_direction = -1 * gradient;
+
+                // step size acceleration
+                double next_step_size = 1.0;
+                auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
+                auto next_radius = radius + (next_step_size * step_direction[2]);
+                ArrayXd next_scaled_residuals =
+                    ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
+                auto next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
+                auto previous_loss = fitting_loss;
+
+                while (next_loss < previous_loss) {
+                  step_size = next_step_size;
+                  fitting_score = -1 * next_loss;
+                  previous_loss = next_loss;
+                  next_step_size *= acceleration_factor;
+
+                  auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
+                  auto next_radius = radius + (next_step_size * step_direction[2]);
+                  ArrayXd next_scaled_residuals =
+                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
+                      bandwidth;
+                  next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
+                }
+              }
+
+              // step size attenuation according to Armijo's rule
+              // if acceleration was successfull, the attenuation is skipped
+              // if acceleration was not successfull, the stpe size is still 1
+              if (step_size == 1) {
+                // to avoid initializing all variables of the while loop before, actual_loss_diff is set to 1
+                // and expected_loss_diff to 0 so that the loop is executed at least once and the variables are properly
+                // initialized in the first iteration of the loop
+                double actual_loss_diff = 1.0;
+                double expected_loss_diff = 0.0;
+                step_size = 1 / armijo_attenuation_factor;
+
+                while (actual_loss_diff > expected_loss_diff && step_size > min_step_size) {
+                  step_size *= armijo_attenuation_factor;
+
+                  auto next_center = center + (step_size * step_direction.head(2)).matrix().transpose();
+                  auto next_radius = radius + (step_size * step_direction[2]);
+                  ArrayXd next_scaled_residuals =
+                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
+                      bandwidth;
+                  auto next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
+                  fitting_score = -1 * next_loss;
+
+                  actual_loss_diff = next_loss - fitting_loss;
+                  expected_loss_diff =
+                      armijo_min_decrease_percentage * step_size * (gradient.transpose() * step_direction.matrix())[0];
+                }
+              }
+
+              auto center_update = (step_size * step_direction.head(2)).matrix().transpose();
+              center = center + center_update;
+              auto radius_update = step_size * step_direction[2];
+              radius = radius + radius_update;
+
+              if (!std::isfinite(center[0]) || !std::isfinite(center[1]) || !std::isfinite(radius) ||
+                  center[0] < break_min_x(idx_batch) || center[0] > break_max_x(idx_batch) ||
+                  center[1] < break_min_y(idx_batch) || center[1] > break_max_y(idx_batch) ||
+                  radius < break_min_radius(idx_batch) || radius > break_max_radius(idx_batch) || radius <= 0 ||
+                  iteration == max_iterations - 1) {
+                diverged = true;
+                break;
+              }
+
+              if ((abs(radius_update) < break_min_change) && (abs(center_update[0]) < break_min_change) &&
+                  (abs(center_update[1]) < break_min_change)) {
+                break;
+              }
+            }
+
+            if (!diverged && fitting_score >= min_fitting_score && std::isfinite(center[0]) &&
+                std::isfinite(center[1]) && std::isfinite(radius) && radius > 0) {
+              int64_t idx = n_start_radius * (n_start_y * (idx_batch * n_start_x + idx_x) + idx_y) + idx_radius;
+              fitted_circles(idx, 0) = center[0];
+              fitted_circles(idx, 1) = center[1];
+              fitted_circles(idx, 2) = radius;
+              fitting_converged(idx) = true;
+              fitting_losses(idx) = -1 * fitting_score;
+            }
+          }
         }
       }
-
-      // step size attenuation according to Armijo's rule
-      // if acceleration was successfull, the attenuation is skipped
-      // if acceleration was not successfull, the stpe size is still 1
-      if (step_size == 1) {
-        // to avoid initializing all variables of the while loop before, actual_loss_diff is set to 1
-        // and expected_loss_diff to 0 so that the loop is executed at least once and the variables are properly
-        // initialized in the first iteration of the loop
-        double actual_loss_diff = 1.0;
-        double expected_loss_diff = 0.0;
-        step_size = 1 / armijo_attenuation_factor;
-
-        while (actual_loss_diff > expected_loss_diff && step_size > min_step_size) {
-          step_size *= armijo_attenuation_factor;
-
-          auto next_center = center + (step_size * step_direction.head(2)).matrix().transpose();
-          auto next_radius = radius + (step_size * step_direction[2]);
-          ArrayXd next_scaled_residuals =
-              ((xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
-          auto next_loss = next_scaled_residuals.unaryExpr(&loss_fn_scalar).sum();
-          fitting_score = -1 * next_loss;
-
-          actual_loss_diff = next_loss - fitting_loss;
-          expected_loss_diff =
-              armijo_min_decrease_percentage * step_size * (gradient.transpose() * step_direction.matrix())[0];
-        }
-      }
-
-      auto center_update = (step_size * step_direction.head(2)).matrix().transpose();
-      center = center + center_update;
-      auto radius_update = step_size * step_direction[2];
-      radius = radius + radius_update;
-
-      if (!std::isfinite(center[0]) || !std::isfinite(center[1]) || !std::isfinite(radius) || center[0] < break_min_x ||
-          center[0] > break_max_x || center[1] < break_min_y || center[1] > break_max_y || radius < break_min_radius ||
-          radius > break_max_radius || radius <= 0 || iteration == max_iterations - 1) {
-        diverged = true;
-        break;
-      }
-
-      if ((abs(radius_update) < break_min_change) && (abs(center_update[0]) < break_min_change) &&
-          (abs(center_update[1]) < break_min_change)) {
-        break;
-      }
-    }
-
-    if (!diverged && fitting_score >= min_fitting_score && std::isfinite(center[0]) && std::isfinite(center[1]) &&
-        std::isfinite(radius) && radius > 0) {
-      fitted_circles(idx, 0) = center[0];
-      fitted_circles(idx, 1) = center[1];
-      fitted_circles(idx, 2) = radius;
-      fitting_converged(idx) = true;
-      fitting_losses(idx) = -1 * fitting_score;
     }
   }
 
-  std::vector<int> converged_indices{};
-  for (int i = 0; i < fitting_converged.size(); ++i) {
-    if (fitting_converged[i]) {
-      converged_indices.push_back(i);
-    }
-  }
+#pragma omp taskwait
 
-  return std::make_tuple(fitted_circles(converged_indices, Eigen::all), fitting_losses(converged_indices));
+  std::vector<ArrayX3d> converged_circles;
+  std::vector<ArrayXd> converged_fitting_losses;
+
+  for (int64_t i = 0; i < n_batches; ++i) {
+    std::vector<int64_t> converged_indices{};
+    int64_t n_circles = n_start_x * n_start_y * n_start_radius;
+    for (int64_t j = 0; j < n_circles; ++j) {
+      auto idx = i * n_circles + j;
+      if (fitting_converged[idx]) {
+        converged_indices.push_back(idx);
+      }
+    }
+    converged_circles.push_back(fitted_circles(converged_indices, Eigen::all));
+    converged_fitting_losses.push_back(fitting_losses(converged_indices));
+  }
+  return std::make_tuple(converged_circles, converged_fitting_losses);
 }
+
 }  // namespace CircleDetection

--- a/csrc/include/CircleDetection/operations.h
+++ b/csrc/include/CircleDetection/operations.h
@@ -1,40 +1,206 @@
 
 #include <Eigen/Dense>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
+#include <set>
+#include <stdexcept>
 #include <vector>
 
+namespace {
 using namespace Eigen;
+using ArrayXl = Eigen::Array<int64_t, Eigen::Dynamic, 1>;
+}  // namespace
 
 namespace CircleDetection {
-std::tuple<ArrayX3d, ArrayXd> non_maximum_suppression(ArrayX3d circles, ArrayXd fitting_scores) {
-  std::vector<int> kept_indices = {};
-  std::vector<int> sorted_indices(circles.rows());
-  std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
-  std::sort(sorted_indices.begin(), sorted_indices.end(),
-            [&fitting_scores](int i, int j) { return fitting_scores(i) < fitting_scores(j); });
 
-  while (sorted_indices.size() > 0) {
-    auto current_idx = sorted_indices[0];
-    sorted_indices.erase(sorted_indices.begin());
-    kept_indices.push_back(current_idx);
-    Vector2d center(circles(current_idx, 0), circles(current_idx, 1));
-    auto radius = circles(current_idx, 2);
+ArrayXd circumferential_completeness_index(ArrayX3d circles, ArrayX2d xy, ArrayXl batch_lengths_circles,
+                                           ArrayXl batch_lengths_xy, int64_t num_regions, double max_dist) {
+  if (batch_lengths_circles.rows() != batch_lengths_xy.rows()) {
+    throw std::invalid_argument("The length of batch_lengths_circles and batch_lengths_xy must be equal.");
+  }
+  if (circles.rows() != batch_lengths_circles.sum()) {
+    throw std::invalid_argument("The number of circles must be equal to the sum of batch_lengths_circles.");
+  }
+  if (xy.rows() != batch_lengths_xy.sum()) {
+    throw std::invalid_argument("The number of points must be equal to the sum of batch_lengths_xy.");
+  }
 
-    auto iter = sorted_indices.begin();
-    while (iter < sorted_indices.end()) {
-      auto other_idx = *iter;
-      Vector2d other_center(circles(other_idx, 0), circles(other_idx, 1));
-      auto other_radius = circles(other_idx, 2);
+  constexpr double PI = 3.14159265358979311600;
 
-      if ((center - other_center).norm() < radius + other_radius) {
-        iter = sorted_indices.erase(iter);
+  int64_t num_batches = batch_lengths_circles.size();
+  ArrayXd circumferential_completeness_indices(circles.rows());
+
+  double angular_step_size = 2 * PI / static_cast<double>(num_regions);
+
+  ArrayXl batch_starts_circles(num_batches);
+  ArrayXl batch_starts_xy(num_batches);
+  ArrayXl batch_indices(circles.rows());
+
+  int64_t batch_start_circles = 0;
+  int64_t batch_start_xy = 0;
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    batch_starts_circles(batch_idx) = batch_start_circles;
+    batch_starts_xy(batch_idx) = batch_start_xy;
+    batch_indices(seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
+    batch_start_circles += batch_lengths_circles(batch_idx);
+    batch_start_xy += batch_lengths_xy(batch_idx);
+  }
+
+#pragma omp parallel for default(shared)
+  for (int64_t idx = 0; idx < circles.rows(); ++idx) {
+    int64_t batch_idx = batch_indices(idx);
+    ArrayXd circle = circles(idx, Eigen::all);
+
+    ArrayX2d centered_xy = xy(seqN(batch_starts_xy(batch_idx), batch_lengths_xy(batch_idx)), Eigen::all).rowwise() -
+                           circle({0, 1}).transpose();
+    ArrayXd radii = centered_xy.rowwise().norm();
+
+    if (centered_xy.rows() == 0) {
+      circumferential_completeness_indices(idx) = 0.0;
+    } else {
+      std::vector<int64_t> circle_xy_indices;
+      if (max_dist < 0) {
+        for (int64_t i = 0; i < radii.rows(); ++i) {
+          if (radii(i) >= 0.7 * circle(2) && radii(i) <= 1.3 * circle(2)) {
+            circle_xy_indices.push_back(i);
+          }
+        }
       } else {
-        ++iter;
+        for (int64_t i = 0; i < radii.rows(); ++i) {
+          if (std::abs(radii(i) - circle(2)) <= max_dist) {
+            circle_xy_indices.push_back(i);
+          }
+        }
+      }
+      ArrayX2d circle_xy = centered_xy(circle_xy_indices, Eigen::all);
+
+      ArrayXd angles = circle_xy(Eigen::all, 1).binaryExpr(circle_xy(Eigen::all, 0), [](double y, double x) {
+        return std::atan2(y, x);
+      });
+
+      ArrayXl sections = (angles / angular_step_size).floor().cast<int64_t>();
+      sections = sections.unaryExpr([num_regions](const int64_t x) { return x % num_regions; });
+
+      std::set<int64_t> filled_sections(sections.data(), sections.data() + sections.size());
+
+      circumferential_completeness_indices(idx) = filled_sections.size() / static_cast<double>(num_regions);
+    }
+  }
+
+  return circumferential_completeness_indices;
+}
+
+std::tuple<ArrayX3d, ArrayXl, ArrayXl> filter_circumferential_completeness_index(
+    ArrayX3d circles, ArrayX2d xy, ArrayXl batch_lengths_circles, ArrayXl batch_lengths_xy, int64_t num_regions,
+    double max_dist, double min_circumferential_completeness_index) {
+  ArrayXd circumferential_completeness_indices =
+      circumferential_completeness_index(circles, xy, batch_lengths_circles, batch_lengths_xy, num_regions, max_dist);
+  int64_t num_batches = batch_lengths_circles.size();
+
+  std::vector<int64_t> filtered_indices = {};
+  ArrayXl filtered_batch_lengths_circles = ArrayXl::Constant(num_batches, 0);
+
+  ArrayXl batch_indices(circles.rows());
+
+  int64_t batch_start_circles = 0;
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    batch_indices(seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
+    batch_start_circles += batch_lengths_circles(batch_idx);
+  }
+
+  for (int64_t i = 0; i < circles.rows(); ++i) {
+    if (circumferential_completeness_indices(i) >= min_circumferential_completeness_index) {
+      filtered_indices.push_back(i);
+      filtered_batch_lengths_circles(batch_indices(i)) += 1;
+    }
+  }
+
+  ArrayXl filtered_indices_array = Eigen::Map<ArrayXl>(filtered_indices.data(), filtered_indices.size());
+
+  return std::make_tuple(circles(filtered_indices, Eigen::all), filtered_batch_lengths_circles, filtered_indices_array);
+}
+
+std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d circles, ArrayXd fitting_losses,
+                                                                        ArrayXl batch_lengths) {
+  if (circles.rows() != fitting_losses.rows()) {
+    throw std::invalid_argument("circles and fitting_losses must have the same number of entries.");
+  }
+
+  if (circles.rows() != batch_lengths.sum()) {
+    throw std::invalid_argument("The number of circles must be equal to the sum of batch_lengths.");
+  }
+
+  int64_t num_batches = batch_lengths.rows();
+
+  ArrayXl batch_starts(num_batches);
+
+  int64_t batch_start = 0;
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    batch_starts(batch_idx) = batch_start;
+    batch_start += batch_lengths(batch_idx);
+  }
+
+  std::vector<std::vector<int64_t>> selected_indices(num_batches);
+  ArrayXl new_batch_lengths = ArrayXl::Constant(num_batches, 0);
+  ArrayXl new_batch_starts = ArrayXl::Constant(num_batches, 0);
+
+#pragma omp parallel for default(shared)
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    int64_t batch_start = batch_starts(batch_idx);
+    int64_t num_circles = circles(seqN(batch_start, batch_lengths(batch_idx)), Eigen::all).rows();
+    std::vector<int64_t> sorted_indices(num_circles);
+    std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
+    std::sort(sorted_indices.begin(), sorted_indices.end(), [&fitting_losses, batch_start](int i, int j) {
+      return fitting_losses(batch_start + i) < fitting_losses(batch_start + j);
+    });
+
+    while (sorted_indices.size() > 0) {
+      auto current_idx = sorted_indices[0];
+      sorted_indices.erase(sorted_indices.begin());
+      selected_indices[batch_idx].push_back(batch_start + current_idx);
+      new_batch_lengths(batch_idx) += 1;
+      Vector2d center(circles(batch_start + current_idx, 0), circles(batch_start + current_idx, 1));
+      auto radius = circles(batch_start + current_idx, 2);
+
+      auto iter = sorted_indices.begin();
+      while (iter < sorted_indices.end()) {
+        auto other_idx = *iter;
+        Vector2d other_center(circles(batch_start + other_idx, 0), circles(batch_start + other_idx, 1));
+        auto other_radius = circles(batch_start + other_idx, 2);
+
+        if ((center - other_center).norm() < radius + other_radius) {
+          iter = sorted_indices.erase(iter);
+        } else {
+          ++iter;
+        }
       }
     }
   }
 
-  return std::make_tuple(circles(kept_indices, Eigen::all), fitting_scores(kept_indices));
+  int64_t total_num_selected_circles = new_batch_lengths.sum();
+
+  ArrayX3d selected_circles(total_num_selected_circles, 3);
+  ArrayXd selected_fitting_losses(total_num_selected_circles);
+  ArrayXl selected_indices_array(total_num_selected_circles);
+
+  batch_start = 0;
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    new_batch_starts(batch_idx) = batch_start;
+    batch_start += new_batch_lengths(batch_idx);
+  }
+
+#pragma omp parallel for default(shared)
+  for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
+    selected_circles(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx)), Eigen::all) =
+        circles(selected_indices[batch_idx], Eigen::all);
+    selected_fitting_losses(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
+        fitting_losses(selected_indices[batch_idx]);
+    selected_indices_array(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
+        Eigen::Map<ArrayXl>(selected_indices[batch_idx].data(), new_batch_lengths(batch_idx));
+  }
+
+  return std::make_tuple(selected_circles, selected_fitting_losses, new_batch_lengths, selected_indices_array);
 }
+
 }  // namespace CircleDetection

--- a/csrc/pybind/operations_pybind.cpp
+++ b/csrc/pybind/operations_pybind.cpp
@@ -18,6 +18,21 @@ PYBIND11_MODULE(_operations_cpp,
     method :code:`circle_detection.operations.non_maximum_suppression()`.
   )pbdoc");
 
+  m.def("circumferential_completeness_index", &CircleDetection::circumferential_completeness_index,
+        pybind11::return_value_policy::reference_internal,
+        R"pbdoc(
+    Calculates the circumferential completeness indices of the specified circles. For more details, see the documentation of the Python wrapper
+    method :code:`circle_detection.operations.circumferential_completeness_index()`.
+  )pbdoc");
+
+  m.def("filter_circumferential_completeness_index", &CircleDetection::filter_circumferential_completeness_index,
+        pybind11::return_value_policy::reference_internal,
+        R"pbdoc(
+    Filters out the circles whose circumferential completeness index is below the specified minimum circumferential
+    completeness index. For more details, see the documentation of the Python wrapper
+    method :code:`circle_detection.operations.filter_circumferential_completeness_index()`.
+  )pbdoc");
+
 #ifdef VERSION_INFO
   m.attr("__version__") = (VERSION_INFO);
 #else

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -2,11 +2,16 @@
 
 __all__ = ["detect_circles"]
 
-from typing import List, Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union, cast
 import numpy as np
 import numpy.typing as npt
 
-from circle_detection.operations import non_maximum_suppression as non_maximum_suppression_op
+from circle_detection.operations import (
+    deduplicate_circles,
+    filter_circumferential_completeness_index,
+    non_maximum_suppression as non_maximum_suppression_op,
+    select_top_k_circles,
+)
 from ._circle_detection_cpp import (  # type: ignore[import-not-found] # pylint: disable = import-error
     detect_circles as detect_circles_cpp,
 )
@@ -15,7 +20,7 @@ from ._circle_detection_cpp import (  # type: ignore[import-not-found] # pylint:
 def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-arguments, too-many-locals, too-many-branches, too-many-statements
     xy: npt.NDArray[np.float64],
     bandwidth: float,
-    batch_indices: Optional[List[List[int]]] = None,
+    batch_lengths: Optional[npt.NDArray[np.int64]] = None,
     min_start_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
     max_start_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
     n_start_x: int = 10,
@@ -40,11 +45,11 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     deduplication_precision: int = 4,
     max_circles: Optional[int] = None,
     min_fitting_score: float = 1e-6,
+    min_circumferential_completeness_idx: Optional[float] = None,
+    circumferential_completeness_idx_max_dist: Optional[float] = None,
+    circumferential_completeness_idx_num_regions: Optional[int] = None,
     non_maximum_suppression: bool = True,
-) -> Union[
-    Tuple[List[npt.NDArray[np.float64]], List[npt.NDArray[np.float64]]],
-    Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
-]:
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64]]:
     r"""
     Detects circles in a set of 2D points using the M-estimator method proposed in `Garlipp, Tim, and Christine
     H. Müller. "Detection of Linear and Circular Shapes in Image Analysis." Computational Statistics & Data Analysis
@@ -169,8 +174,13 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     Args:
         xy: Coordinates of the set of 2D points in which to detect circles.
         bandwidth: Kernel bandwidth.
-        batch_indices: Indices indicating to which input point set each point in the batch belongs. If set to
-            :code:`None`, it is assumed that all input points belong to the same point set. Defaults to :code:`None`.
+        batch_lengths: Number of points in each point set of the input batch. For batch processing, it is
+            expected that all points belonging to the same point set are stored consecutively in the :code:`xy` input
+            array. For example, if the input is a batch of two point sets (i.e., two batch items) with :math:`N_1`
+            points and :math:`N_2` points, then :code:`batch_lengths` should be set to :code:`[N_1, N_2]` and
+            :code:`xy[:N_1]` should contain the points of the first point set and :code:`circles[N_1:]` the points of
+            the second point set. If :code:`batch_lengths` is set to :code:`None`, it is assumed that the input points
+            all belong to the same point set and batch processing is disabled. Defaults to :code:`None`.
         min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Can be either a
             scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
             used for all batch items. If set to :code:`None`, the minimum of the x-coordinates in of the points within
@@ -248,18 +258,28 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
             Defaults to 1000.
         min_fitting_score: Minimum fitting score (equal to -1 :math:`\cdot` fitting loss) that a circle must have in
             order not to be discarded. Defaults to :math:`10^{-6}`.
+        min_circumferential_completeness_idx: Minimum
+            `circumferential completeness index <https://doi.org/10.3390/rs12101652>`__ that a circle must have in
+            order to not be discarded. If :code:`min_circumferential_completeness_idx` is set,
+            :code:`circumferential_completeness_idx_num_regions` must also be set. If
+            :code:`min_circumferential_completeness_idx` is :code:`None`, no filtering based on the circumferential
+            completeness index is done. Defaults to :code:`None`.
+        circumferential_completeness_idx_max_dist: Maximum distance a point can have to the circle outline to be counted
+            as part of the circle when computing the circumferential completeness index. If set to :code:`None`,
+            points are counted as part of the circle if their distance to the circle is center is in the interval
+            :math:`[0.7 \cdot r, 1.3 \cdot r]` where :math:`r` is the circle radius. Defaults to :code:`None`.
+        circumferential_completeness_idx_num_regions: Number of angular regions for computing the circumferential
+            completeness index. Must not be :code:`None`, if :code:`min_circumferential_completeness_idx` is not
+            :code:`None`. Defaults to :code:`None`.
         non_maximum_suppression: Whether non-maximum suppression should be applied to the detected circles. If this
             option is enabled, circles that overlap with other circles, are only kept if they have the lowest fitting
             loss among the circles with which they overlap. Defaults to :code:`True`.
 
     Returns:
-        : Tuple of two lists of arrays if :code:`batch_indices` is not :code:`None`, and tuple of two arrays otherwise.
-        In the first case, both lists contain one array per batch item. The arrays in the first list
-        (if :code:`batch_indices` is not :code:`None`) / the first array (if :code:`batch_indices` is :code:`None`)
-        contain the parameters of the detected circles (in the following order: x-coordinate of the center, y-coordinate
-        of the center, radius). The arrays in the second list (if :code:`batch_indices` is not :code:`None`) / the
-        second array (if :code:`batch_indices` is :code:`None`) contain the fitting losses of the detected circles
-        (lower means better).
+        : Tuple of three arrays. The first array contains the parameters of the detected circles (in the following
+        order: x-coordinate of the center, y-coordinate of the center, radius). The second array contains the fitting
+        losses of the detected circles (lower means better). The third array contains the number of circles detected for
+        each batch item (circles belonging to the same batch item are stored consecutively in the output array).
 
     Raises:
         ValueError: if :code:`min_start_x` is larger than :code:`max_start_x` for any batch item.
@@ -281,6 +301,9 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         ValueError: if :code:`acceleration_factor` is smaller than or equal to 1.
         ValueError: if :code:`armijo_attenuation_factor` is not within :math:`(0, 1)`.
         ValueError: if :code:`armijo_min_decrease_percentage` is not within :math:`(0, 1)`.
+
+        ValueError: if :code:`min_circumferential_completeness_idx` is not :code:`None` and
+          :code:`circumferential_completeness_idx_num_regions` is :code:`None`
 
     Shape:
         - :code:`xy`: :math:`(N, 2)`
@@ -310,37 +333,54 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         | :math:`C = \text{ number of detected circles}`
         | :math:`C_i = \text{ number of circles detected for the i-th batch item}`
     """
-    batch_indices_was_none = False
-    if batch_indices is None:
-        batch_indices = [np.arange(len(xy), dtype=np.int64).tolist()]
-        batch_indices_was_none = True
-    num_batches = len(batch_indices)
+    if batch_lengths is None:
+        batch_lengths = np.array([len(xy)], dtype=np.int64)
+    num_batches = len(batch_lengths)
+    batch_starts = np.cumsum(np.concatenate(([0], batch_lengths)))[:-1]
+    batch_ends = np.cumsum(batch_lengths)
 
     if num_batches == 0:
-        raise ValueError("The list of batch indices is empty.")
+        raise ValueError("batch_lengths must contain at least one entry.")
+
+    if min_circumferential_completeness_idx is not None and circumferential_completeness_idx_num_regions is None:
+        raise ValueError(
+            "circumferential_completeness_idx_num_regions must be set if min_circumferential_completeness_idx is set."
+        )
 
     if min_start_x is None:
-        min_start_x = np.array([xy[indices, 0].min() if len(indices) else 0 for indices in batch_indices])
+        min_start_x = np.array(
+            [
+                xy[batch_start:batch_end, 0].min() if batch_start < batch_end else 0
+                for (batch_start, batch_end) in zip(batch_starts, batch_ends)
+            ],
+            dtype=np.float64,
+        )
     elif not isinstance(min_start_x, np.ndarray):
-        min_start_x = np.full(num_batches, fill_value=min_start_x, dtype=xy.dtype)
+        min_start_x = np.full(num_batches, fill_value=min_start_x, dtype=np.float64)
     min_start_x = cast(npt.NDArray[np.float64], min_start_x)
 
     if max_start_x is None:
-        max_start_x = np.array([xy[indices, 0].max() if len(indices) else 1 for indices in batch_indices])
+        max_start_x = np.array(
+            [
+                xy[batch_start:batch_end, 0].max() if batch_start < batch_end else 0
+                for (batch_start, batch_end) in zip(batch_starts, batch_ends)
+            ],
+            dtype=np.float64,
+        )
     elif not isinstance(max_start_x, np.ndarray):
-        max_start_x = np.full(num_batches, fill_value=max_start_x, dtype=xy.dtype)
+        max_start_x = np.full(num_batches, fill_value=max_start_x, dtype=np.float64)
     max_start_x = cast(npt.NDArray[np.float64], max_start_x)
 
     if break_min_x is None:
         break_min_x = min_start_x
     elif not isinstance(break_min_x, np.ndarray):
-        break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=xy.dtype)
+        break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=np.float64)
     break_min_x = cast(npt.NDArray[np.float64], break_min_x)
 
     if break_max_x is None:
         break_max_x = max_start_x
     elif not isinstance(break_max_x, np.ndarray):
-        break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=xy.dtype)
+        break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=np.float64)
     break_max_x = cast(npt.NDArray[np.float64], break_max_x)
 
     if (min_start_x > max_start_x).any():
@@ -351,27 +391,39 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         raise ValueError("max_start_x must be smaller than or equal to break_max_x.")
 
     if min_start_y is None:
-        min_start_y = np.array([xy[indices, 1].min() if len(indices) else 0 for indices in batch_indices])
+        min_start_y = np.array(
+            [
+                xy[batch_start:batch_end, 1].min() if batch_start < batch_end else 0
+                for (batch_start, batch_end) in zip(batch_starts, batch_ends)
+            ],
+            dtype=np.float64,
+        )
     elif not isinstance(min_start_y, np.ndarray):
-        min_start_y = np.full(num_batches, fill_value=min_start_y, dtype=xy.dtype)
+        min_start_y = np.full(num_batches, fill_value=min_start_y, dtype=np.float64)
     min_start_y = cast(npt.NDArray[np.float64], min_start_y)
 
     if max_start_y is None:
-        max_start_y = np.array([xy[indices, 1].max() if len(indices) else 0 for indices in batch_indices])
+        max_start_y = np.array(
+            [
+                xy[batch_start:batch_end, 1].max() if batch_start < batch_end else 0
+                for (batch_start, batch_end) in zip(batch_starts, batch_ends)
+            ],
+            dtype=np.float64,
+        )
     elif not isinstance(max_start_y, np.ndarray):
-        max_start_y = np.full(num_batches, fill_value=max_start_y, dtype=xy.dtype)
+        max_start_y = np.full(num_batches, fill_value=max_start_y, dtype=np.float64)
     max_start_y = cast(npt.NDArray[np.float64], max_start_y)
 
     if break_max_y is None:
         break_min_y = min_start_y
     elif not isinstance(break_max_y, np.ndarray):
-        break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=xy.dtype)
+        break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=np.float64)
     break_min_y = cast(npt.NDArray[np.float64], break_min_y)
 
     if break_max_y is None:
         break_max_y = max_start_y
     elif not isinstance(break_max_y, np.ndarray):
-        break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=xy.dtype)
+        break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=np.float64)
     break_max_y = cast(npt.NDArray[np.float64], break_max_y)
 
     if (min_start_y > max_start_y).any():
@@ -384,30 +436,35 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     if max_start_radius is None:
         max_start_radius = np.array(
             [
-                (xy[indices].max(axis=0) - xy[indices].min(axis=0)).max() if len(indices) else 0.1
-                for indices in batch_indices
+                (
+                    (xy[batch_start:batch_end].max(axis=0) - xy[batch_start:batch_end].min(axis=0)).max()
+                    if batch_start < batch_end
+                    else 0.1
+                )
+                for (batch_start, batch_end) in zip(batch_starts, batch_ends)
             ]
         )
+        max_start_radius = np.full(num_batches, fill_value=max_start_radius, dtype=np.float64)
     elif not isinstance(max_start_radius, np.ndarray):
-        max_start_radius = np.full(num_batches, fill_value=max_start_radius, dtype=xy.dtype)
+        max_start_radius = np.full(num_batches, fill_value=max_start_radius, dtype=np.float64)
     max_start_radius = cast(npt.NDArray[np.float64], max_start_radius)
 
     if min_start_radius is None:
         min_start_radius = 0.1 * max_start_radius  # type: ignore[assignment]
     elif not isinstance(min_start_radius, np.ndarray):
-        min_start_radius = np.full(num_batches, fill_value=min_start_radius, dtype=xy.dtype)
+        min_start_radius = np.full(num_batches, fill_value=min_start_radius, dtype=np.float64)
     min_start_radius = cast(npt.NDArray[np.float64], min_start_radius)
 
     if break_min_radius is None:
         break_min_radius = min_start_radius
     elif not isinstance(break_min_radius, np.ndarray):
-        break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=xy.dtype)
+        break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=np.float64)
     break_min_radius = cast(npt.NDArray[np.float64], break_min_radius)
 
     if break_max_radius is None:
         break_max_radius = max_start_radius
     elif not isinstance(break_max_radius, np.ndarray):
-        break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=xy.dtype)
+        break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=np.float64)
     break_max_radius = cast(npt.NDArray[np.float64], break_max_radius)
 
     if (min_start_radius < 0).any():
@@ -439,9 +496,9 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
 
     break_min_radius = np.maximum(break_min_radius, 0)
 
-    result = detect_circles_cpp(
+    detected_circles, fitting_losses, batch_lengths_circles = detect_circles_cpp(
         xy,
-        batch_indices,
+        batch_lengths,
         float(bandwidth),
         min_start_x,
         max_start_x,
@@ -467,26 +524,33 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         float(min_fitting_score),
     )
 
-    detected_circles, fitting_losses = result
+    detected_circles, batch_lengths_circles, selected_indices = deduplicate_circles(
+        detected_circles, deduplication_precision, batch_lengths=batch_lengths_circles
+    )
+    fitting_losses = fitting_losses[selected_indices]
 
-    for batch_idx in range(num_batches):
-        detected_circles[batch_idx] = np.round(detected_circles[batch_idx], decimals=deduplication_precision)
-        detected_circles[batch_idx], kept_indices = np.unique(detected_circles[batch_idx], return_index=True, axis=0)
-        fitting_losses[batch_idx] = fitting_losses[batch_idx][kept_indices]
+    if non_maximum_suppression and (max_circles is None or max_circles > 1):
+        detected_circles, fitting_losses, batch_lengths_circles, _ = non_maximum_suppression_op(
+            detected_circles, fitting_losses, batch_lengths_circles
+        )
 
-        if non_maximum_suppression and (max_circles is None or max_circles > 1):
-            detected_circles[batch_idx], fitting_losses[batch_idx] = non_maximum_suppression_op(
-                detected_circles[batch_idx], fitting_losses[batch_idx]
-            )
+    if min_circumferential_completeness_idx is not None:
+        if circumferential_completeness_idx_max_dist is None:
+            circumferential_completeness_idx_max_dist = bandwidth
+        detected_circles, batch_lengths_circles, selected_indices = filter_circumferential_completeness_index(
+            detected_circles,
+            xy,
+            num_regions=cast(int, circumferential_completeness_idx_num_regions),
+            min_circumferential_completeness_index=min_circumferential_completeness_idx,
+            max_dist=circumferential_completeness_idx_max_dist,
+            batch_lengths_circles=batch_lengths_circles,
+            batch_lengths_xy=batch_lengths,
+        )
+        fitting_losses = fitting_losses[selected_indices]
 
-        if max_circles is not None:
-            sorting_indices = np.argsort(fitting_losses[batch_idx])
-            detected_circles[batch_idx] = detected_circles[batch_idx][sorting_indices]
-            fitting_losses[batch_idx] = fitting_losses[batch_idx][sorting_indices]
-            detected_circles[batch_idx] = detected_circles[batch_idx][:max_circles]
-            fitting_losses[batch_idx] = fitting_losses[batch_idx][:max_circles]
+    if max_circles is not None:
+        detected_circles, fitting_losses, batch_lengths_circles, _ = select_top_k_circles(
+            detected_circles, fitting_losses, k=max_circles, batch_lengths=batch_lengths_circles
+        )
 
-    if batch_indices_was_none:
-        return detected_circles[0], fitting_losses[0]
-
-    return detected_circles, fitting_losses
+    return detected_circles, fitting_losses, batch_lengths_circles

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -166,6 +166,8 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     Args:
         xy: Coordinates of the set of 2D points in which to detect circles.
         bandwidth: Kernel bandwidth.
+        batch_indices: Indices indicating to which input point set each point in the batch belongs. If set to
+            :code:`None` it is assumed that all input points belong to the same point set. Defaults to :code:`None`.
         min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Defaults to
             :code:`None`. If set to :code:`None`, the minimum of the x-coordinates in :code:`xy` is used as the default.
         max_start_x: Upper limit of the start values for the x-coordinates of the circle centers. Defaults to

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -171,46 +171,64 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         bandwidth: Kernel bandwidth.
         batch_indices: Indices indicating to which input point set each point in the batch belongs. If set to
             :code:`None`, it is assumed that all input points belong to the same point set. Defaults to :code:`None`.
-        min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Defaults to
-            :code:`None`. If set to :code:`None`, the minimum of the x-coordinates in :code:`xy` is used as the default.
-        max_start_x: Upper limit of the start values for the x-coordinates of the circle centers. Defaults to
-            :code:`None`. If set to :code:`None`, the maximum of the x-coordinates in :code:`xy` is used as the default.
+        min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Can be either a
+            scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
+            used for all batch items. If set to :code:`None`, the minimum of the x-coordinates in of the points within
+            each batch item is used as the default. Defaults to :code:`None`. 
+        max_start_x: Upper limit of the start values for the x-coordinates of the circle centers. Can be either a
+            scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
+            used for all batch items. If set to :code:`None`, the maximum of the x-coordinates in of the points within
+            each batch item is used as the default. Defaults to :code:`None`.
         n_start_x: Number of start values for the x-coordinates of the circle centers. Defaults to 10.
-        min_start_y: Lower limit of the start values for the y-coordinates of the circle centers. Defaults to
-            :code:`None`. If set to :code:`None`, the minimum of the y-coordinates in :code:`xy` is used as the default.
-        max_start_y: Upper limit of the start values for the y-coordinates of the circle centers. Defaults to
-            :code:`None`. If set to :code:`None`, the minimum of the y-coordinates in :code:`xy` is used as the default.
+        min_start_y: Lower limit of the start values for the y-coordinates of the circle centers. Can be either a
+            scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
+            used for all batch items. If set to :code:`None`, the minimum of the y-coordinates in of the points within
+            each batch item is used as the default. Defaults to :code:`None`.
+        max_start_y: Upper limit of the start values for the y-coordinates of the circle centers. Can be either a
+            scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
+            used for all batch items. If set to :code:`None`, the maximum of the y-coordinates in of the points within
+            each batch item is used as the default. Defaults to :code:`None`.
         n_start_y: Number of start values for the y-coordinates of the circle centers. Defaults to 10.
-        min_start_radius: Lower limit of the start values for the circle radii. Defaults to :code:`None`. If set to
-            :code:`None`, the :code:`0.1 * max_start_radius` is used as the default.
-        max_start-radius: Upper limit of the start values for the circle radii. Defaults to :code:`None`. If set to
-            :code:`None`, the axis-aligned bounding box of :code:`xy` is computed and the length of the longer side of
-            the bounding box is used as the default.
+        min_start_radius: Lower limit of the start values for the circle radii. Can be either a scalar, an array of
+            values (one per batch item), or :code:`None`. If a scalar is provided, the same value is used for all batch
+            items. If set to :code:`None`, :code:`0.1 * max_start_radius` is used as the default. Defaults to
+            :code:`None`.
+        max_start-radius: Upper limit of the start values for the circle radii. Can be either a scalar, an array of
+            values (one per batch item), or :code:`None`. If a scalar is provided, the same value is used for all batch
+            items. If set to :code:`None`, the axis-aligned bounding box of the points within each batch item is
+            computed and the length of the longer side of the bounding box is used as the default. Defaults to
+            :code:`None`.
         n_start_radius: Number of start values for the circle radii. Defaults to 10.
         break_min_x: Termination criterion for circle optimization. If the x-coordinate of a circle center becomes
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`min_start_x` is
-            used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`min_start_x` is used as the default. Defaults to :code:`None`. 
         break_max_x: Termination criterion for circle optimization. If the x-coordinate of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`max_start_x` is
-            used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`max_start_x` is used as the default. Defaults to :code:`None`. 
         break_min_y: Termination criterion for circle optimization. If the y-coordinate of a circle center becomes
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`min_start_y` is
-            used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`min_start_y` is used as the default. Defaults to :code:`None`. 
         break_max_y: Termination criterion for circle optimization. If the y-coordinate of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`max_start_y` is
-            used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`max_start_y` is used as the default. Defaults to :code:`None`. 
         break_min_radius: Termination criterion for circle optimization. If the radius of a circle center becomes
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`min_start_radius`
-            is used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`min_start_radius` is used as the default. Defaults to :code:`None`. 
         break_max_radius: Termination criterion for circle optimization. If the radius of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
-            respective circle is discarded. Defaults to :code:`None`. If set to :code:`None`, :code:`max_start_radius`
-            is used as the default.
+            respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
+            :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
+            :code:`max_start_radius` is used as the default. Defaults to :code:`None`. 
         break_min_change: Termination criterion for circle optimization. If the updates of all circle parameters in an
             iteration are smaller than this threshold, the optimization of the respective circle is terminated.
             Defaults to :math:`10^{-5}`.

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -170,7 +170,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         xy: Coordinates of the set of 2D points in which to detect circles.
         bandwidth: Kernel bandwidth.
         batch_indices: Indices indicating to which input point set each point in the batch belongs. If set to
-            :code:`None` it is assumed that all input points belong to the same point set. Defaults to :code:`None`.
+            :code:`None`, it is assumed that all input points belong to the same point set. Defaults to :code:`None`.
         min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Defaults to
             :code:`None`. If set to :code:`None`, the minimum of the x-coordinates in :code:`xy` is used as the default.
         max_start_x: Upper limit of the start values for the x-coordinates of the circle centers. Defaults to
@@ -236,23 +236,25 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
 
     Returns:
         : Tuple of two lists of arrays if :code:`batch_indices` is not :code:`None`, and tuple of two arrays otherwise.
-        In the first case, both lists contain one array per batch item. The arrays in the first tuple element contain
-        the parameters of the detected circles (in the following order: x-coordinate of the center, y-coordinate
-        of the center, radius). The arrays in the second tuple element contain the fitting losses of the detected
-        circles (lower means better).
+        In the first case, both lists contain one array per batch item. The arrays in the first list
+        (if :code:`batch_indices` is not :code:`None`) / the first array (if :code:`batch_indices` is :code:`None`)
+        contain the parameters of the detected circles (in the following order: x-coordinate of the center, y-coordinate
+        of the center, radius). The arrays in the second list (if :code:`batch_indices` is not :code:`None`) / the
+        second array (if :code:`batch_indices` is :code:`None`) contain the fitting losses of the detected circles
+        (lower means better).
 
     Raises:
-        ValueError: if :code:`min_start_x` is larger than :code:`max_start_x`.
-        ValueError: if :code:`min_start_x` is smaller than :code:`break_min_x`.
-        ValueError: if :code:`max_start_x` is smaller than :code:`break_max_x`.
+        ValueError: if :code:`min_start_x` is larger than :code:`max_start_x` for any batch item.
+        ValueError: if :code:`min_start_x` is smaller than :code:`break_min_x` for any batch item.
+        ValueError: if :code:`max_start_x` is smaller than :code:`break_max_x` for any batch item.
 
-        ValueError: if :code:`min_start_y` is larger than :code:`max_start_y`.
-        ValueError: if :code:`min_start_y` is smaller than :code:`break_min_y`.
-        ValueError: if :code:`max_start_y` is smaller than :code:`break_max_y`.
+        ValueError: if :code:`min_start_y` is larger than :code:`max_start_y` for any batch item.
+        ValueError: if :code:`min_start_y` is smaller than :code:`break_min_y` for any batch item.
+        ValueError: if :code:`max_start_y` is smaller than :code:`break_max_y` for any batch item.
 
-        ValueError: if :code:`min_start_radius` is larger than :code:`max_start_radius`.
-        ValueError: if :code:`min_start_radius` is smaller than :code:`break_min_radius`.
-        ValueError: if :code:`max_start_radius` is larger than :code:`break_max_radius`.
+        ValueError: if :code:`min_start_radius` is larger than :code:`max_start_radius` for any batch item.
+        ValueError: if :code:`min_start_radius` is smaller than :code:`break_min_radius` for any batch item.
+        ValueError: if :code:`max_start_radius` is larger than :code:`break_max_radius` for any batch item.
 
         ValueError: if :code:`n_start_x` is not a positive number.
         ValueError: if :code:`n_start_y` is not a positive number.
@@ -264,7 +266,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
 
     Shape:
         - :code:`xy`: :math:`(N, 2)`
-        - :code:`batch_indices`: list of length :math:`(B)` where each list element is an array of length :math:`N_i`
+        - :code:`batch_indices`: list of length :math:`B` where each list element is an array of shape :math:`(N_i)`
         - :code:`min_start_x`: scalar or array of shape :math:`(B)`
         - :code:`max_start_x`: scalar or array of shape :math:`(B)`
         - :code:`max_start_y`: scalar or array of shape :math:`(B)`
@@ -277,10 +279,10 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         - :code:`break_max_y`: scalar or array of shape :math:`(B)`
         - :code:`break_min_radius`: scalar or array of shape :math:`(B)`
         - :code:`break_max_radius`: scalar or array of shape :math:`(B)`
-        - Output: If :code:`batch_indices` is not :code:`None`, two lists of length :math:`(B)` are returned. In the
+        - Output: If :code:`batch_indices` is not :code:`None`, two lists of length :math:`B` are returned. In the
           first list, each element is an array of shape :math:`(C_i, 3)`, and in the second list each element is an
           array of shape :math:`(C_i)`. If :code:`batch_indices` is :code:`None`, the output is an tuple of two arrays,
-          where the first array has shape :code:`(C, 3)` and the second array has shape :math:`(C)`.
+          where the first array has shape :math:`(C, 3)` and the second array has shape :math:`(C)`.
 
         | where
         |

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -307,7 +307,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
 
     Shape:
         - :code:`xy`: :math:`(N, 2)`
-        - :code:`batch_indices`: list of length :math:`B` where each list element is an array of shape :math:`(N_i)`
+        - :code:`batch_lengths`: :math:`(B)`
         - :code:`min_start_x`: scalar or array of shape :math:`(B)`
         - :code:`max_start_x`: scalar or array of shape :math:`(B)`
         - :code:`max_start_y`: scalar or array of shape :math:`(B)`
@@ -320,18 +320,14 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         - :code:`break_max_y`: scalar or array of shape :math:`(B)`
         - :code:`break_min_radius`: scalar or array of shape :math:`(B)`
         - :code:`break_max_radius`: scalar or array of shape :math:`(B)`
-        - Output: If :code:`batch_indices` is not :code:`None`, two lists of length :math:`B` are returned. In the
-          first list, each element is an array of shape :math:`(C_i, 3)`, and in the second list each element is an
-          array of shape :math:`(C_i)`. If :code:`batch_indices` is :code:`None`, the output is an tuple of two arrays,
-          where the first array has shape :math:`(C, 3)` and the second array has shape :math:`(C)`.
+        - Output: The first array in the output tuple has shape :math:`(C, 3)`, the second shape :math:`(C)`, and the
+          third shape :math:`(B)`.
 
         | where
         |
         | :math:`B = \text{ batch size}`
         | :math:`N = \text{ number of points}`
-        | :math:`N_i = \text{ number of points belonging to the i-th batch item}`
         | :math:`C = \text{ number of detected circles}`
-        | :math:`C_i = \text{ number of circles detected for the i-th batch item}`
     """
     if batch_lengths is None:
         batch_lengths = np.array([len(xy)], dtype=np.int64)

--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -174,7 +174,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         min_start_x: Lower limit of the start values for the x-coordinates of the circle centers. Can be either a
             scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
             used for all batch items. If set to :code:`None`, the minimum of the x-coordinates in of the points within
-            each batch item is used as the default. Defaults to :code:`None`. 
+            each batch item is used as the default. Defaults to :code:`None`.
         max_start_x: Upper limit of the start values for the x-coordinates of the circle centers. Can be either a
             scalar, an array of values (one per batch item), or :code:`None`. If a scalar is provided, the same value is
             used for all batch items. If set to :code:`None`, the maximum of the x-coordinates in of the points within
@@ -203,32 +203,32 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`min_start_x` is used as the default. Defaults to :code:`None`. 
+            :code:`min_start_x` is used as the default. Defaults to :code:`None`.
         break_max_x: Termination criterion for circle optimization. If the x-coordinate of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`max_start_x` is used as the default. Defaults to :code:`None`. 
+            :code:`max_start_x` is used as the default. Defaults to :code:`None`.
         break_min_y: Termination criterion for circle optimization. If the y-coordinate of a circle center becomes
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`min_start_y` is used as the default. Defaults to :code:`None`. 
+            :code:`min_start_y` is used as the default. Defaults to :code:`None`.
         break_max_y: Termination criterion for circle optimization. If the y-coordinate of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`max_start_y` is used as the default. Defaults to :code:`None`. 
+            :code:`max_start_y` is used as the default. Defaults to :code:`None`.
         break_min_radius: Termination criterion for circle optimization. If the radius of a circle center becomes
             smaller than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`min_start_radius` is used as the default. Defaults to :code:`None`. 
+            :code:`min_start_radius` is used as the default. Defaults to :code:`None`.
         break_max_radius: Termination criterion for circle optimization. If the radius of a circle center becomes
             greater than this value during optimization, the optimization of the respective circle is terminated and the
             respective circle is discarded. Can be either a scalar, an array of values (one per batch item), or
             :code:`None`. If a scalar is provided, the same value is used for all batch items. If set to :code:`None`,
-            :code:`max_start_radius` is used as the default. Defaults to :code:`None`. 
+            :code:`max_start_radius` is used as the default. Defaults to :code:`None`.
         break_min_change: Termination criterion for circle optimization. If the updates of all circle parameters in an
             iteration are smaller than this threshold, the optimization of the respective circle is terminated.
             Defaults to :math:`10^{-5}`.

--- a/src/circle_detection/operations/__init__.py
+++ b/src/circle_detection/operations/__init__.py
@@ -1,6 +1,8 @@
 """ Post-processing operations for the circle detection. """
 
 from ._circumferential_completeness_index import *
+from ._deduplicate_circles import *
 from ._non_maximum_suppression import *
+from ._select_top_k_circles import *
 
 __all__ = [name for name in globals().keys() if not name.startswith("_")]

--- a/src/circle_detection/operations/_circumferential_completeness_index.py
+++ b/src/circle_detection/operations/_circumferential_completeness_index.py
@@ -63,9 +63,9 @@ def circumferential_completeness_index(
 
     Raises:
         ValueError: If the length of :code:`circles` is not equal to the sum of :code:`batch_lengths_circles`, if
-        the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
-        :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
-        :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
+            the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
+            :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
+            :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
 
     Shape:
         - :code:`circles`: :math:`(C, 3)`
@@ -142,9 +142,9 @@ def filter_circumferential_completeness_index(
 
     Raises:
         ValueError: If the length of :code:`circles` is not equal to the sum of :code:`batch_lengths_circles`, if
-        the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
-        :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
-        :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
+            the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
+            :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
+            :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
 
     Shape:
         - :code:`circles`: :math:`(C, 3)`

--- a/src/circle_detection/operations/_circumferential_completeness_index.py
+++ b/src/circle_detection/operations/_circumferential_completeness_index.py
@@ -1,15 +1,28 @@
 """ Operations to calculate the circumferential completeness index and to filter circles based on this metric. """
 
-__all__ = ["circumferential_completeness_index", "filter_circumferential_completeness_index"]
+__all__ = [
+    "circumferential_completeness_index",
+    "filter_circumferential_completeness_index",
+]
 
 from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
 
+from circle_detection.operations._operations_cpp import (  # type: ignore[import-not-found] # pylint: disable=import-error, no-name-in-module
+    circumferential_completeness_index as circumferential_completeness_index_cpp,
+    filter_circumferential_completeness_index as filter_circumferential_completeness_index_cpp,
+)
+
 
 def circumferential_completeness_index(
-    circles: npt.NDArray[np.float64], xy: npt.NDArray[np.float64], num_regions: int, max_dist: Optional[float] = None
+    circles: npt.NDArray[np.float64],
+    xy: npt.NDArray[np.float64],
+    num_regions: int,
+    max_dist: Optional[float] = None,
+    batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
+    batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
 ) -> npt.NDArray[np.float64]:
     r"""
     Calculates the circumferential completeness indices of the specified circles. The circumferential completeness index
@@ -19,7 +32,10 @@ def circumferential_completeness_index(
     <https://doi.org/10.3390/rs12101652>`__ To calculate the circumference completeness index of a circle, the circle is
     divided into :code:`num_regions` angular regions. An angular region is considered complete if it contains at least
     one point whose distance to the circle outline is equal to or less than :code:`max_dist`. The circumferential
-    completeness index is then defined as the proportion of angular regions that are complete.
+    completeness index is then defined as the proportion of angular regions that are complete. This method supports
+    batch processing, i.e. separate sets of circles (i.e., different batch items) can be processed in parallel. For this
+    purpose, :code:`batch_lengths_circles` and :code:`batch_lengths_xy` must be set to specify which circle / which
+    point belongs to which set.
 
     Args:
         circles: Parameters of the circles for which to compute the circumferential completeness indices. Each circle
@@ -30,54 +46,72 @@ def circumferential_completeness_index(
         max_dist: Maximum distance a point can have to the circle outline to be counted as part of the circle. If set to
             :code:`None`, points are counted as part of the circle if their distance to the circle is center is in the
             interval :math:`[0.7 \cdot r, 1.3 \cdot r]` where :math:`r` is the circle radius. Defaults to :code:`None`.
+        batch_lengths_circles: Number of circles in each item of the input batch. For batch processing, it is
+            expected that all circles belonging to the same batch item are stored consecutively in the :code:`circles`
+            input array. For example, if a batch comprises two batch items with :math:`N_1` circles and :math:`N_2`
+            circles, then :code:`batch_lengths_circles` should be set to :code:`[N_1, N_2]` and :code:`circles[:N_1]`
+            should contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch
+            item. If :code:`batch_lengths_circles` is set to :code:`None`, it is assumed that the input circles
+            belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
+        batch_lengths_xy: Number of points in each item of the input batch. For batch processing, it is
+            expected that all points belonging to the same batch item are stored consecutively in the :code:`xy`
+            input array. If :code:`batch_lengths_xy` is set to :code:`None`, it is assumed that the input points
+            belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
 
     Returns:
         Circumferential completeness indices of the circles.
 
+    Raises:
+        ValueError: If the length of :code:`circles` is not equal to the sum of :code:`batch_lengths_circles`, if
+        the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
+        :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
+        :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
+
     Shape:
         - :code:`circles`: :math:`(C, 3)`
         - :code:`xy`: :math:`(N, 2)`
+        - :code:`batch_lengths_circles`: :math:`(B)`
+        - :code:`batch_lengths_circles`: :math:`(B)`
         - Output: :math:`(C)`
 
         | where
         |
+        | :math:`B = \text{ batch size}`
         | :math:`C = \text{ number of circles}`
         | :math:`N = \text{ number of points}`
     """
-    circumferential_completeness_indices = np.full(len(circles), fill_value=0, dtype=np.float64)
 
-    angular_step_size = 2 * np.pi / num_regions
+    if batch_lengths_circles is None and batch_lengths_xy is not None:
+        raise ValueError("batch_lengths_circles must not be None if batch_lengths_xy is specified.")
+    if batch_lengths_xy is None and batch_lengths_circles is not None:
+        raise ValueError("batch_lengths_xy must not be None if batch_lengths_circles is specified.")
 
-    circle: npt.NDArray[np.float64]
-    for idx, circle in enumerate(circles):  # type: ignore[assignment]
-        centered_points = xy - circle[:2]
-        radii = np.linalg.norm(centered_points, axis=-1)
+    if batch_lengths_circles is None:
+        batch_lengths_circles = np.array([len(circles)], dtype=np.int64)
+    if batch_lengths_xy is None:
+        batch_lengths_xy = np.array([len(xy)], dtype=np.int64)
+    if max_dist is None:
+        max_dist = -1
 
-        if max_dist is None:
-            circle_points = centered_points[np.logical_and(radii >= 0.7 * circle[2], radii <= 1.3 * circle[2])]
-        else:
-            circle_points = centered_points[np.abs(radii - circle[2]) <= max_dist]
-
-        angles = np.arctan2(circle_points[:, 1], circle_points[:, 0])
-
-        sections = np.remainder(np.floor(angles / angular_step_size).astype(np.int64), num_regions)
-        filled_sections = np.unique(sections)
-
-        circumferential_completeness_indices[idx] = len(filled_sections) / num_regions
-
-    return circumferential_completeness_indices
+    return circumferential_completeness_index_cpp(
+        circles, xy, batch_lengths_circles, batch_lengths_xy, int(num_regions), float(max_dist)
+    )
 
 
 def filter_circumferential_completeness_index(
     circles: npt.NDArray[np.float64],
     xy: npt.NDArray[np.float64],
-    min_circumferential_completeness_index: float,
     num_regions: int,
+    min_circumferential_completeness_index: float,
     max_dist: Optional[float] = None,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]:
+    batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
+    batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Filters out the circles whose circumferential completeness index is below the specified minimum circumferential
-    completeness index.
+    completeness index. This method supports batch processing, i.e. separate sets of circles (i.e., different batch
+    items) can be filtered in parallel. For this purpose, :code:`batch_lengths_circles` and :code:`batch_lengths_xy`
+    must be set to specify which circle / which point belongs to which set.
 
     Args:
         circles: Parameters of the circles for which to compute the circumferential completeness indices. Each circle
@@ -85,33 +119,64 @@ def filter_circumferential_completeness_index(
             center, radius.
         xy: Coordinates of the set of 2D points to which the circles were fitted.
         num_regions: Number of angular regions.
+        min_circumferential_completeness_index: Minimum circumferential index a point must have to not be discarded.
         max_dist: Maximum distance a point can have to the circle outline to be counted as part of the circle. If set to
             :code:`None`, points are counted as part of the circle if their distance to the circle is center is in the
             interval :math:`[0.7 \cdot r, 1.3 \cdot r]` where :math:`r` is the circle radius. Defaults to :code:`None`.
-        min_circumferential_completeness_index: Minimum circumferential index a point must have to not be discarded.
+        batch_lengths_circles: Number of circles in each item of the input batch. For batch processing, it is
+            expected that all circles belonging to the same batch item are stored consecutively in the :code:`circles`
+            input array. For example, if a batch comprises two batch items with :math:`N_1` circles and :math:`N_2`
+            circles, then :code:`batch_lengths_circles` should be set to :code:`[N_1, N_2]` and :code:`circles[:N_1]`
+            should contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch
+            item. If :code:`batch_lengths_circles` is set to :code:`None`, it is assumed that the input circles
+            belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
+        batch_lengths_xy: Number of points in each item of the input batch. For batch processing, it is
+            expected that all points belonging to the same batch item are stored consecutively in the :code:`xy`
+            input array. If :code:`batch_lengths_xy` is set to :code:`None`, it is assumed that the input points
+            belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
 
     Returns:
-        Tuple consisting of two arrays. The first contains the parameters of the circles remaining after filtering. The
-        second contains the indices of the retained circles in the original circle array.
+        : Tuple of three arrays. The first contains the parameters of the circles remaining after filtering.
+        The second contains the number of circles in each item of the output batch. The third contains the indices of
+        the selected circles in the input array.
+
+    Raises:
+        ValueError: If the length of :code:`circles` is not equal to the sum of :code:`batch_lengths_circles`, if
+        the length of :code:`xy` is not equal to the sum of :code:`batch_lengths_xy`, if
+        :code:`batch_lengths_circles` is :code:`None` and :code:`batch_lengths_xy` not (or vice versa), or if
+        :code:`batch_lengths_circles` and :code:`batch_lengths_xy` have different lengths.
 
     Shape:
         - :code:`circles`: :math:`(C, 3)`
         - :code:`xy`: :math:`(N, 2)`
-        - Output: Tuple of two arrays. The first has shape :math:`(C', 3)` and the second has shape :math:`(C)`.
+        - Output: Tuple of three arrays. The first has shape :math:`(C', 3)` and the second shape :math:`(B)`, and the
+          third shape :math:`(C')`.
 
         | where
         |
+        | :math:`B = \text{ batch size}`
         | :math:`C = \text{ number of circles before the filtering}`
         | :math:`C' = \text{ number of circles after the filtering}`
         | :math:`N = \text{ number of points}`
     """
+    if batch_lengths_circles is None and batch_lengths_xy is not None:
+        raise ValueError("batch_lengths_circles must not be None if batch_lengths_xy is specified.")
+    if batch_lengths_xy is None and batch_lengths_circles is not None:
+        raise ValueError("batch_lengths_xy must not be None if batch_lengths_circles is specified.")
 
-    circumferential_completeness_indices = circumferential_completeness_index(
-        circles, xy, max_dist=max_dist, num_regions=num_regions
+    if batch_lengths_circles is None:
+        batch_lengths_circles = np.array([len(circles)], dtype=np.int64)
+    if batch_lengths_xy is None:
+        batch_lengths_xy = np.array([len(xy)], dtype=np.int64)
+    if max_dist is None:
+        max_dist = -1
+
+    return filter_circumferential_completeness_index_cpp(
+        circles,
+        xy,
+        batch_lengths_circles,
+        batch_lengths_xy,
+        int(num_regions),
+        float(max_dist),
+        float(min_circumferential_completeness_index),
     )
-    filter_mask = circumferential_completeness_indices >= min_circumferential_completeness_index
-
-    selected_indices = np.arange(len(circles), dtype=np.int64)[filter_mask]
-    circles = circles[selected_indices]
-
-    return circles, selected_indices

--- a/src/circle_detection/operations/_deduplicate_circles.py
+++ b/src/circle_detection/operations/_deduplicate_circles.py
@@ -1,0 +1,80 @@
+""" Deduplication of circles. """
+
+__all__ = ["deduplicate_circles"]
+
+from typing import Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+def deduplicate_circles(
+    circles: npt.NDArray[np.float64],
+    deduplication_precision: int,
+    batch_lengths: Optional[npt.NDArray[np.int64]] = None,
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    r"""
+    Deduplicates circles whose parameters do not differ up to the decimal place specified by
+    :code:`deduplication_precision`. This method supports batch processing, i.e. separate sets of
+    circles (i.e., different batch items) can be processed in parallel. For this purpose, :code:`batch_lengths` must be
+    set to specify which circle belongs to which set.
+
+    Args:
+        circles: Parameters of the circles to deduplicate (in the following order: x-coordinate of the center,
+            y-coordinate of the center, radius).
+        deduplication_precision: Number of decimal places taken into account for deduplication.
+        batch_lengths: Number of circles in each item of the input batch. For batch processing, it is expected that
+            all circles and fitting losses belonging to the same batch item are stored consecutively in the respective
+            input array. For example, if a batch comprises two batch items with :math:`N_1` circles and :math:`N_2`
+            circles, then :code:`batch_lengths` should be set to :code:`[N_1, N_2]` and :code:`circles[:N_1]` should
+            contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch item.
+            If :code:`batch_lengths` is set to :code:`None`, it is assumed that the input circles belong to a single
+            batch item and batch processing is disabled. Defaults to :code:`None`.
+
+    Returns:
+        : Tuple of three arrays: The first contains the parameters of the circles remaining after deduplication. The
+        second contains the number of circles in each item of the output batch. The third contains the indices of the
+        selected circles in the input array.
+
+    Raises:
+        ValueError: If :code:`batch_lengths: is not :code:`None` and the length of :code:`circles` is not equal to the
+            sum of :code:`batch_lengths`.
+
+    Shape:
+        - :code:`circles`: :math:`(C, 3)`
+        - :code:`batch_lengths`: :math:`(B)`
+        - Output: The first array in the output tuple has shape :math:`(C', 3)`, the second shape :math:`(B)`, and the
+          third shape :math:`(C')`.
+
+        | where
+        |
+        | :math:`B = \text{ batch size}`
+        | :math:`C = \text{ number of circles before deduplication}`
+        | :math:`C' = \text{ number of circles after deduplication}`
+    """
+
+    if batch_lengths is not None and len(circles) != batch_lengths.sum():
+        raise ValueError("The number of circles must be equal to the sum of batch_lengths.")
+
+    if batch_lengths is None or len(batch_lengths) == 1:
+        rounded_circles = np.round(circles, decimals=deduplication_precision)
+
+        unique_rounded_circles, selected_indices = np.unique(rounded_circles, return_index=True, axis=0)
+
+        return circles[selected_indices], np.array([len(unique_rounded_circles)], dtype=np.int64), selected_indices
+
+    # add batch indices as first dimension to separate circles from different batch items
+    rounded_circles = np.empty((len(circles), 4), dtype=np.int64)
+    rounded_circles[:, 0] = np.repeat(np.arange(len(batch_lengths), dtype=np.float64), batch_lengths)
+    rounded_circles[:, 1:] = np.round(circles, decimals=deduplication_precision)
+
+    unique_rounded_circles, selected_indices = np.unique(rounded_circles, return_index=True, axis=0)
+
+    batch_item_borders_mask = np.empty(len(unique_rounded_circles), dtype=np.bool)
+    batch_item_borders_mask[:1] = True
+    batch_item_borders_mask[1:] = unique_rounded_circles[1:, 0] != unique_rounded_circles[:-1, 0]
+    deduplicated_batch_lengths = np.diff(
+        np.concatenate(np.nonzero(batch_item_borders_mask) + ([len(batch_item_borders_mask)],))
+    )
+
+    return circles[selected_indices], deduplicated_batch_lengths, selected_indices

--- a/src/circle_detection/operations/_deduplicate_circles.py
+++ b/src/circle_detection/operations/_deduplicate_circles.py
@@ -37,7 +37,7 @@ def deduplicate_circles(
         selected circles in the input array.
 
     Raises:
-        ValueError: If :code:`batch_lengths: is not :code:`None` and the length of :code:`circles` is not equal to the
+        ValueError: If :code:`batch_lengths` is not :code:`None` and the length of :code:`circles` is not equal to the
             sum of :code:`batch_lengths`.
 
     Shape:

--- a/src/circle_detection/operations/_non_maximum_suppression.py
+++ b/src/circle_detection/operations/_non_maximum_suppression.py
@@ -2,7 +2,7 @@
 
 __all__ = ["non_maximum_suppression"]
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -13,29 +13,51 @@ from circle_detection.operations._operations_cpp import (  # type: ignore[import
 
 
 def non_maximum_suppression(
-    circles: npt.NDArray[np.float64], fitting_losses: npt.NDArray[np.float64]
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
+    circles: npt.NDArray[np.float64],
+    fitting_losses: npt.NDArray[np.float64],
+    batch_lengths: Optional[npt.NDArray[np.int64]] = None,
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Non-maximum suppression operation to remove overlapping circles. If a circle overlaps with other circles, it is
-    only kept if it has the lowest fitting loss among the circles with which it overlaps.
+    only kept if it has the lowest fitting loss among the circles with which it overlaps. This method supports batch
+    processing, i.e. separate sets of circles (i.e., different batch items) can be processed in parallel. For this
+    purpose, :code:`batch_lengths` must be set to specify which circle belongs to which set.
 
     Args:
         circles: Parameters of the circles to which apply non-maximum suppression (in the following order:
             x-coordinate of the center, y-coordinate of the center, radius).
         fitting_losses: Fitting losses of the circles to which apply non-maximum suppression (lower means better).
+        batch_lengths: Number of circles in each item of the input batch. For batch processing, it is expected that
+            all circles and fitting losses belonging to the same batch item are stored consecutively in the respective
+            input array. For example, if a batch comprises two batch items with :math:`N_1` circles and :math:`N_2`
+            circles, then :code:`batch_lengths` should be set to :code:`[N_1, N_2]` and :code:`circles[:N_1]` should
+            contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch item.
+            If :code:`batch_lengths` is set to :code:`None`, it is assumed that the input circles belong to a single
+            batch item and batch processing is disabled. Defaults to :code:`None`.
 
     Returns:
-        : Tuple of two arrays. The first contains the parameters of the circles remaining after non-maximum suppression
-        and the second the corresponding fitting losses.
+        : Tuple of four arrays. The first contains the parameters of the circles remaining after non-maximum
+        suppression and the second the corresponding fitting losses. The third contains the number of circles in each
+        item of the output batch. The fourth contains the indices of the selected circles in the input array.
+
+    Raises:
+        ValueError: If :code:`circles` and :code:`fitting_losses` have different lengths or if :code:`batch_lengths` is
+            not :code:`None` and the length of :code:`circles` is not equal to the sum of :code:`batch_lengths`.
 
     Shape:
         - :code:`circles`: :math:`(C, 3)`
         - :code:`fitting_losses`: :math:`(C)`
-        - Output: The first array in the output tuple has shape :math:`(C, 3)` and the second shape :math:`(C)`.
+        - :code:`batch_lengths`: :math:`(B)`
+        - Output: The first array in the output tuple has shape :math:`(C', 3)`, the second shape :math:`(C')`, the
+          third shape :math:`(B)`, and the fourth has shape :math:`(C')`.
 
         | where
         |
-        | :math:`C = \text{ number of circles}`
+        | :math:`B = \text{ batch size}`
+        | :math:`C = \text{ number of circles before applying non-maximum suppression}`
+        | :math:`C' = \text{ number of circles after applying non-maximum suppression}`
     """
+    if batch_lengths is None:
+        batch_lengths = np.array([len(circles)], dtype=np.int64)
 
-    return non_maximum_suppression_cpp(circles, fitting_losses)
+    return non_maximum_suppression_cpp(circles, fitting_losses, batch_lengths)

--- a/src/circle_detection/operations/_select_top_k_circles.py
+++ b/src/circle_detection/operations/_select_top_k_circles.py
@@ -39,7 +39,7 @@ def select_top_k_circles(
         fourth contains the indices of the selected circles in the input array.
 
     Raises:
-        ValueError: If :code:`circles` and :code:`fitting_losses` have different lengths or if :code:`batch_lengths: is
+        ValueError: If :code:`circles` and :code:`fitting_losses` have different lengths or if :code:`batch_lengths` is
             not :code:`None` and the length of :code:`circles` is not equal to the sum of :code:`batch_lengths`.
 
     Shape:

--- a/src/circle_detection/operations/_select_top_k_circles.py
+++ b/src/circle_detection/operations/_select_top_k_circles.py
@@ -52,8 +52,8 @@ def select_top_k_circles(
         | where
         |
         | :math:`B = \text{ batch size}`
-        | :math:`C = \text{ number of circles before filtering}`
-        | :math:`C' = \text{ number of circles after filtering}`
+        | :math:`C = \text{ number of circles before the filtering}`
+        | :math:`C' = \text{ number of circles after the filtering}`
     """
     if len(circles) != len(fitting_losses):
         raise ValueError("circles and fitting_losses must have the same number of entries.")

--- a/src/circle_detection/operations/_select_top_k_circles.py
+++ b/src/circle_detection/operations/_select_top_k_circles.py
@@ -1,0 +1,87 @@
+""" Selection of circles with the lowest fitting losses. """
+
+__all__ = ["select_top_k_circles"]
+
+from typing import Optional, Tuple
+
+import numpy as np
+import numpy.typing as npt
+
+
+def select_top_k_circles(
+    circles: npt.NDArray[np.float64],
+    fitting_losses: npt.NDArray[np.float64],
+    k: int,
+    batch_lengths: Optional[npt.NDArray[np.int64]] = None,
+) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+    r"""
+    Selects the :code:`k` circles with the lowest fitting losses from a set of circles. If the set of circles contains
+    less than :code:`k` circles, all circles are kept. This method supports batch processing, i.e. separate sets of
+    circles (i.e., different batch items) can be filtered in parallel. For this purpose, :code:`batch_lengths` must be
+    set to specify which circle belongs to which set.
+
+    Args:
+        circles: Parameters of the circles to filter (in the following order: x-coordinate of the center, y-coordinate
+            of the center, radius).
+        fitting_losses: Fitting losses of the circles to filter (lower means better).
+        k: Number of circles to select from each set of circles.
+        batch_lengths: Number of circles in each item of the input batch. For batch processing, it is expected that
+            all circles and fitting losses belonging to the same batch item are stored consecutively in the respective
+            input array. For example, if a batch comprises two batch items with :math:`N_1` circles and :math:`N_2`
+            circles, then :code:`batch_lengths` should be set to :code:`[N_1, N_2]` and :code:`circles[:N_1]` should
+            contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch item.
+            If :code:`batch_lengths` is set to :code:`None`, it is assumed that the input circles belong to a single
+            batch item and batch processing is disabled. Defaults to :code:`None`.
+
+    Returns:
+        : Tuple of four arrays: The first contains the parameters of the selected circles and the second the
+        corresponding fitting losses. The third contains the number of circles in each item of the output batch. The
+        fourth contains the indices of the selected circles in the input array.
+
+    Raises:
+        ValueError: If :code:`circles` and :code:`fitting_losses` have different lengths or if :code:`batch_lengths: is
+            not :code:`None` and the length of :code:`circles` is not equal to the sum of :code:`batch_lengths`.
+
+    Shape:
+        - :code:`circles`: :math:`(C, 3)`
+        - :code:`fitting_losses`: :math:`(C)`
+        - :code:`batch_lengths`: :math:`(B)`
+        - Output: The first array in the output tuple has shape :math:`(C', 3)`, the second shape :math:`(C')`, the
+          third shape :math:`(B)`, and the fourth shape :math:`(C')`.
+
+        | where
+        |
+        | :math:`B = \text{ batch size}`
+        | :math:`C = \text{ number of circles before filtering}`
+        | :math:`C' = \text{ number of circles after filtering}`
+    """
+    if len(circles) != len(fitting_losses):
+        raise ValueError("circles and fitting_losses must have the same number of entries.")
+
+    if batch_lengths is not None and len(circles) != batch_lengths.sum():
+        raise ValueError("The number of circles must be equal to the sum of batch_lengths.")
+
+    if batch_lengths is None or len(batch_lengths) == 1:
+        sorting_indices = np.argsort(fitting_losses)
+
+        batch_lengths = np.array([min(k, len(circles))], dtype=np.int64)
+        selected_indices = np.arange(len(circles), dtype=np.int64)[sorting_indices][:k]
+
+        return circles[sorting_indices][:k], fitting_losses[sorting_indices][:k], batch_lengths, selected_indices
+
+    batch_indices = np.repeat(np.arange(len(batch_lengths), dtype=np.float64), batch_lengths)
+    sorting_indices = np.lexsort((fitting_losses, batch_indices))
+    selected_indices = np.cumsum(np.concatenate(([0], batch_lengths)))[:-1]
+
+    offsets = np.arange(k, dtype=np.int64)
+    selected_indices = selected_indices[:, None] + offsets
+    valid_mask = offsets[None, :] < batch_lengths[:, None]
+
+    selected_indices = selected_indices[valid_mask]
+    selected_indices = np.arange(len(circles), dtype=np.int64)[sorting_indices][selected_indices]
+    selected_indices = np.sort(selected_indices)
+
+    filtered_batch_lengths = np.full(len(batch_lengths), fill_value=k, dtype=np.int64)
+    filtered_batch_lengths = np.minimum(filtered_batch_lengths, batch_lengths)  # type: ignore[assignment]
+
+    return circles[selected_indices], fitting_losses[selected_indices], filtered_batch_lengths, selected_indices

--- a/test/operations/test_circumferential_completeness_index.py
+++ b/test/operations/test_circumferential_completeness_index.py
@@ -11,17 +11,25 @@ from circle_detection.operations import circumferential_completeness_index, filt
 class TestCircumferentialCompletenessIndex:  # pylint: disable=too-few-public-methods
     """Tests for :code:`circle_detection.operations.circumferential_completeness_index`."""
 
+    @pytest.mark.parametrize("pass_batch_lengths", [True, False])
     @pytest.mark.parametrize("max_dist", [0.1, None])
-    def test_circumferential_completeness_index(self, max_dist: Optional[float]):
+    def test_circumferential_completeness_index(self, pass_batch_lengths: bool, max_dist: Optional[float]):
         circles = np.array([[0, 0, 1], [5, 0, 1]], dtype=np.float64)
-
         xy = np.array([[0, 1], [0, -1], [1, 0], [-1, 0], [5, 1], [5, -1]], dtype=np.float64)
+
+        if pass_batch_lengths:
+            batch_lengths_circles = np.array([len(circles)], dtype=np.int64)
+            batch_lengths_xy = np.array([len(xy)], dtype=np.int64)
+        else:
+            batch_lengths_circles = None
+            batch_lengths_xy = None
+
         num_regions = 4
 
         expected_circumferential_completness_indices = np.array([1, 0.5], dtype=np.float64)
 
         circumferential_completeness_indices = circumferential_completeness_index(
-            circles, xy, num_regions=num_regions, max_dist=max_dist
+            circles, xy, num_regions, max_dist, batch_lengths_circles, batch_lengths_xy
         )
 
         np.testing.assert_array_equal(
@@ -29,11 +37,130 @@ class TestCircumferentialCompletenessIndex:  # pylint: disable=too-few-public-me
         )
 
         expected_filtered_circles = circles[:1]
-        expected_selected_indices = np.array([0], dtype=np.int64)
+        expected_batch_lengths_circles = np.array([1], dtype=np.int64)
 
-        filtered_circles, selected_indices = filter_circumferential_completeness_index(
-            circles, xy, min_circumferential_completeness_index=0.6, num_regions=num_regions, max_dist=max_dist
+        filtered_circles, batch_lengths_circles, selected_indices = filter_circumferential_completeness_index(
+            circles,
+            xy,
+            min_circumferential_completeness_index=0.6,
+            num_regions=num_regions,
+            max_dist=max_dist,
+            batch_lengths_circles=batch_lengths_circles,
+            batch_lengths_xy=batch_lengths_xy,
         )
 
         np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
-        np.testing.assert_array_equal(expected_selected_indices, selected_indices)
+        np.testing.assert_array_equal(expected_batch_lengths_circles, batch_lengths_circles)
+        np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
+
+    def test_batch_processing(self):
+        circles = np.array([[0, 0, 1], [5, 0, 1], [7, 0, 1], [0, 0, 0.1]], dtype=np.float64)
+        xy = np.array([[0, 1], [0, -1], [1, 0], [-1, 0], [5, 1], [5, -1], [7, 1], [7, -1], [8, 0]], dtype=np.float64)
+        batch_lengths_circles = np.array([1, 2, 1], dtype=np.int64)
+        batch_lengths_xy = np.array([4, 5, 0], dtype=np.int64)
+
+        max_dist = 0.1
+        num_regions = 4
+
+        expected_circumferential_completness_indices = np.array([1, 0.5, 3 / 4, 0], dtype=np.float64)
+
+        circumferential_completeness_indices = circumferential_completeness_index(
+            circles, xy, num_regions, max_dist, batch_lengths_circles, batch_lengths_xy
+        )
+
+        np.testing.assert_array_equal(
+            expected_circumferential_completness_indices, circumferential_completeness_indices
+        )
+
+        expected_filtered_circles = np.array([circles[0], circles[2]], dtype=np.float64)
+        expected_filtered_batch_lengths_circles = np.array([1, 1, 0], dtype=np.int64)
+
+        filtered_circles, filtered_batch_lengths_circles, selected_indices = filter_circumferential_completeness_index(
+            circles,
+            xy,
+            min_circumferential_completeness_index=0.6,
+            num_regions=num_regions,
+            max_dist=max_dist,
+            batch_lengths_circles=batch_lengths_circles,
+            batch_lengths_xy=batch_lengths_xy,
+        )
+
+        np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
+        np.testing.assert_array_equal(expected_filtered_batch_lengths_circles, filtered_batch_lengths_circles)
+        np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
+
+    def test_invalid_batch_lengths_circles(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        batch_lengths_circles = np.array([2], dtype=np.int64)
+        xy = np.zeros((10, 2), dtype=np.float64)
+        batch_lengths_xy = np.array([len(xy)], dtype=np.int64)
+
+        num_regions = 4
+
+        with pytest.raises(ValueError):
+            circumferential_completeness_index(
+                circles, xy, num_regions, batch_lengths_circles=batch_lengths_circles, batch_lengths_xy=batch_lengths_xy
+            )
+
+        with pytest.raises(ValueError):
+            filter_circumferential_completeness_index(
+                circles,
+                xy,
+                num_regions,
+                min_circumferential_completeness_index=0.6,
+                batch_lengths_circles=batch_lengths_circles,
+                batch_lengths_xy=batch_lengths_xy,
+            )
+
+    def test_invalid_batch_lengths_xy(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        batch_lengths_circles = np.array([len(circles)], dtype=np.int64)
+        xy = np.zeros((10, 2), dtype=np.float64)
+        batch_lengths_xy = np.array([5], dtype=np.int64)
+
+        num_regions = 4
+
+        with pytest.raises(ValueError):
+            circumferential_completeness_index(
+                circles, xy, num_regions, batch_lengths_circles=batch_lengths_circles, batch_lengths_xy=batch_lengths_xy
+            )
+
+        with pytest.raises(ValueError):
+            filter_circumferential_completeness_index(
+                circles,
+                xy,
+                num_regions,
+                min_circumferential_completeness_index=0.6,
+                batch_lengths_circles=batch_lengths_circles,
+                batch_lengths_xy=batch_lengths_xy,
+            )
+
+    @pytest.mark.parametrize("omit_batch_lengths_circles", [True, False])
+    def test_inconsistent_batch_lengths(self, omit_batch_lengths_circles: bool):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        if omit_batch_lengths_circles:
+            batch_lengths_circles = None
+        else:
+            batch_lengths_circles = np.array([2, 2], dtype=np.int64)
+        xy = np.zeros((10, 2), dtype=np.float64)
+        if not omit_batch_lengths_circles:
+            batch_lengths_xy = None
+        else:
+            batch_lengths_xy = np.array([5, 5], dtype=np.int64)
+
+        num_regions = 4
+
+        with pytest.raises(ValueError):
+            circumferential_completeness_index(
+                circles, xy, num_regions, batch_lengths_circles=batch_lengths_circles, batch_lengths_xy=batch_lengths_xy
+            )
+
+        with pytest.raises(ValueError):
+            filter_circumferential_completeness_index(
+                circles,
+                xy,
+                num_regions,
+                min_circumferential_completeness_index=0.6,
+                batch_lengths_circles=batch_lengths_circles,
+                batch_lengths_xy=batch_lengths_xy,
+            )

--- a/test/operations/test_deduplicate_circles.py
+++ b/test/operations/test_deduplicate_circles.py
@@ -1,0 +1,82 @@
+""" Tests for circle_detection.operations.deduplicate_circles. """
+
+import numpy as np
+import pytest
+
+from circle_detection.operations import deduplicate_circles
+
+
+class TestDeduplicateCircles:
+    """Tests for circle_detection.operations.deduplicate_circles."""
+
+    @pytest.mark.parametrize("pass_batch_lengths", [True, False])
+    def test_single_batch_item(self, pass_batch_lengths: bool):
+        circles = np.array([[0, 0, 1], [0, 0, 0.99]], dtype=np.float64)
+        batch_lengths = None
+        if pass_batch_lengths:
+            batch_lengths = np.array([2], dtype=np.int64)
+        deduplication_precision = 1
+
+        deduplicated_circles, deduplicated_batch_lengths, selected_indices = deduplicate_circles(
+            circles, deduplication_precision=deduplication_precision, batch_lengths=batch_lengths
+        )
+
+        np.testing.assert_array_equal(deduplicated_circles, circles[selected_indices])
+        np.testing.assert_array_equal(np.array([1], dtype=np.int64), deduplicated_batch_lengths)
+
+    def test_batch_processing(self):
+        circles = np.array(
+            [[0, 0, 1], [1, 0, 1], [0, 0, 1.01], [0, 0, 1], [2, 2, 2], [1, 1, 1], [1, 1, 1]], dtype=np.float64
+        )
+        batch_lengths = np.array([4, 3], dtype=np.int64)
+
+        expected_deduplicated_circles = np.array([[0, 0, 1], [1, 0, 1], [1, 1, 1], [2, 2, 2]], dtype=np.float64)
+        expected_deduplicated_batch_lengths = np.array([2, 2], dtype=np.int64)
+
+        deduplication_precision = 1
+
+        deduplicated_circles, deduplicated_batch_lengths, selected_indices = deduplicate_circles(
+            circles, deduplication_precision=deduplication_precision, batch_lengths=batch_lengths
+        )
+
+        batch_item_start = 0
+        for batch_item_size in expected_deduplicated_batch_lengths:
+            current_deduplicated_circles = np.round(
+                deduplicated_circles[batch_item_start:batch_item_size], decimals=deduplication_precision
+            )
+            sorted_indices = np.lexsort(
+                (
+                    current_deduplicated_circles[:, 2],
+                    current_deduplicated_circles[:, 1],
+                    current_deduplicated_circles[:, 0],
+                )
+            )
+            np.testing.assert_array_equal(
+                expected_deduplicated_circles[batch_item_start:batch_item_size],
+                current_deduplicated_circles[sorted_indices],
+            )
+            batch_item_start += batch_item_size
+
+        np.testing.assert_array_equal(deduplicated_circles, circles[selected_indices])
+        np.testing.assert_array_equal(expected_deduplicated_batch_lengths, deduplicated_batch_lengths)
+
+    @pytest.mark.parametrize("deduplication_precision", [1, 4])
+    def test_rounding_precision(self, deduplication_precision: int):
+        circles = np.array([[0, 0, 1], [0.0001, 0.0001, 0.9999]], dtype=np.float64)
+        batch_lengths = np.array([2], dtype=np.int64)
+
+        deduplicated_circles, _, _ = deduplicate_circles(
+            circles, deduplication_precision=deduplication_precision, batch_lengths=batch_lengths
+        )
+
+        if deduplication_precision < 4:
+            assert len(deduplicated_circles) == 1
+        else:
+            assert len(deduplicated_circles) == len(circles)
+
+    def test_invalid_inputs(self):
+        circles = np.zeros((2, 3), dtype=np.float64)
+        batch_lengths = np.array([3], dtype=np.int64)
+
+        with pytest.raises(ValueError):
+            deduplicate_circles(circles, deduplication_precision=1, batch_lengths=batch_lengths)

--- a/test/operations/test_non_maximum_suppression.py
+++ b/test/operations/test_non_maximum_suppression.py
@@ -1,6 +1,7 @@
 """ Tests for :code:`circle_detection.operations.non_maximum_suppression`. """
 
 import numpy as np
+import pytest
 
 from circle_detection.operations import non_maximum_suppression
 
@@ -8,23 +9,68 @@ from circle_detection.operations import non_maximum_suppression
 class TestNonMaximumSuppression:
     """Tests for :code:`circle_detection.operations.non_maximum_suppression`."""
 
-    def test_non_overlapping_circles(self):
+    @pytest.mark.parametrize("pass_batch_lengths", [True, False])
+    def test_non_overlapping_circles(self, pass_batch_lengths: bool):
         circles = np.array([[0, 0, 1], [3, 0, 0.5], [0, 2, 0.1]], dtype=np.float64)
         fitting_losses = np.zeros(3, dtype=np.float64)
+        batch_lengths = np.array([3], dtype=np.int64)
 
-        filtered_circles, filtered_fitting_losses = non_maximum_suppression(circles, fitting_losses)
+        filtered_circles, filtered_fitting_losses, filtered_batch_lengths, selected_indices = non_maximum_suppression(
+            circles, fitting_losses, batch_lengths if pass_batch_lengths else None
+        )
 
         np.testing.assert_array_equal(circles, filtered_circles)
         np.testing.assert_array_equal(fitting_losses, filtered_fitting_losses)
+        np.testing.assert_array_equal(batch_lengths, filtered_batch_lengths)
+        np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
 
     def test_overlapping_circles(self):
         circles = np.array([[0, 0, 1], [0.9, 0.1, 1], [0, 2, 0.1]], dtype=np.float64)
         fitting_losses = np.array([-1, -2, -3], dtype=np.float64)
+        batch_lengths = np.array([len(circles)], dtype=np.int64)
 
         expected_filtered_circles = np.array([[0, 2, 0.1], [0.9, 0.1, 1]], dtype=np.float64)
         expected_filtered_fitting_losses = np.array([-3, -2], dtype=np.float64)
+        expected_filtered_batch_lengths = np.array([len(expected_filtered_circles)], dtype=np.int64)
 
-        filtered_circles, filtered_fitting_losses = non_maximum_suppression(circles, fitting_losses)
+        filtered_circles, filtered_fitting_losses, filtered_batch_lengths, selected_indices = non_maximum_suppression(
+            circles, fitting_losses, batch_lengths
+        )
 
         np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
         np.testing.assert_array_equal(expected_filtered_fitting_losses, filtered_fitting_losses)
+        np.testing.assert_array_equal(expected_filtered_batch_lengths, filtered_batch_lengths)
+        np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
+
+    def test_batch_processing(self):
+        circles = np.array([[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6]], dtype=np.float64)
+        fitting_losses = np.array([-5, -4, -3, -2, -1], dtype=np.float64)
+        batch_lengths = np.array([2, 3], dtype=np.int64)
+
+        expected_filtered_circles = np.array([[0, 0, 1], [0, 0, 0.8]], dtype=np.float64)
+        expected_filtered_fitting_losses = np.array([-5, -3], dtype=np.float64)
+        expected_filtered_batch_lengths = np.array([1, 1], dtype=np.int64)
+
+        filtered_circles, filtered_fitting_losses, filtered_batch_lengths, selected_indices = non_maximum_suppression(
+            circles, fitting_losses, batch_lengths
+        )
+
+        np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
+        np.testing.assert_array_equal(expected_filtered_fitting_losses, filtered_fitting_losses)
+        np.testing.assert_array_equal(expected_filtered_batch_lengths, filtered_batch_lengths)
+        np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
+
+    def test_invalid_inputs(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        fitting_losses = np.zeros((2), dtype=np.float64)
+
+        with pytest.raises(ValueError):
+            non_maximum_suppression(circles, fitting_losses)
+
+    def test_invalid_batch_lengths(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        fitting_losses = np.zeros((4), dtype=np.float64)
+        batch_lengths = np.array([2], dtype=np.int64)
+
+        with pytest.raises(ValueError):
+            non_maximum_suppression(circles, fitting_losses, batch_lengths)

--- a/test/operations/test_select_top_k_circles.py
+++ b/test/operations/test_select_top_k_circles.py
@@ -1,0 +1,83 @@
+""" Tests for :code:`circle_detection.operations.select_top_k_circles`. """
+
+import numpy as np
+import pytest
+
+from circle_detection.operations import select_top_k_circles
+
+
+class TestSelectTopKCircles:
+    """Tests for :code:`circle_detection.operations.select_top_k_circles`."""
+
+    @pytest.mark.parametrize("pass_batch_lengths", [True, False])
+    def test_single_batch_item(self, pass_batch_lengths: bool):
+        circles = np.array([[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8]], dtype=np.float64)
+        fitting_losses = np.array([-1, -3, -2])
+        batch_lengths = None
+        if pass_batch_lengths:
+            batch_lengths = np.array([3], dtype=np.int64)
+
+        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8]])
+        expected_fitting_losses = np.array([-3, -2])
+        expected_batch_lengths = np.array([2])
+        expected_selected_indices = np.array([1, 2])
+
+        k = 2
+        selected_circles, selected_fitting_losses, selected_batch_lengths, selected_indices = select_top_k_circles(
+            circles, fitting_losses, k=k, batch_lengths=batch_lengths
+        )
+
+        np.testing.assert_array_equal(expected_circles, selected_circles)
+        np.testing.assert_array_equal(expected_fitting_losses, selected_fitting_losses)
+        np.testing.assert_array_equal(expected_batch_lengths, selected_batch_lengths)
+        np.testing.assert_array_equal(expected_selected_indices, selected_indices)
+
+    def test_batch_processing(self):
+        circles = np.array(
+            [[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6], [0, 0, 0.5]], dtype=np.float64
+        )
+        fitting_losses = np.array([-1, -3, -2, -1, -2, -1])
+        batch_lengths = np.array([3, 2, 1], dtype=np.int64)
+
+        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6], [0, 0, 0.5]])
+        expected_fitting_losses = np.array([-3, -2, -1, -2, -1])
+        expected_batch_lengths = np.array([2, 2, 1])
+        expected_selected_indices = np.array([1, 2, 3, 4, 5])
+
+        k = 2
+        selected_circles, selected_fitting_losses, selected_batch_lengths, selected_indices = select_top_k_circles(
+            circles, fitting_losses, k=k, batch_lengths=batch_lengths
+        )
+
+        np.testing.assert_array_equal(expected_circles, selected_circles)
+        np.testing.assert_array_equal(expected_fitting_losses, selected_fitting_losses)
+        np.testing.assert_array_equal(expected_batch_lengths, selected_batch_lengths)
+        np.testing.assert_array_equal(expected_selected_indices, selected_indices)
+
+    def test_k_larger_than_input(self):
+        circles = np.array([[0, 0, 0.5]], dtype=np.float64)
+        fitting_losses = np.array([0], dtype=np.float64)
+        k = 2
+        selected_circles, selected_fitting_losses, selected_batch_lengths, selected_indices = select_top_k_circles(
+            circles, fitting_losses, k=k
+        )
+
+        np.testing.assert_array_equal(circles, selected_circles)
+        np.testing.assert_array_equal(fitting_losses, selected_fitting_losses)
+        np.testing.assert_array_equal(np.array([1], dtype=np.int64), selected_batch_lengths)
+        np.testing.assert_array_equal(np.array([0], dtype=np.int64), selected_indices)
+
+    def test_invalid_inputs(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        fitting_losses = np.zeros((2), dtype=np.float64)
+
+        with pytest.raises(ValueError):
+            select_top_k_circles(circles, fitting_losses, k=1)
+
+    def test_invalid_batch_lengths(self):
+        circles = np.zeros((4, 3), dtype=np.float64)
+        fitting_losses = np.zeros((4), dtype=np.float64)
+        batch_lengths = np.array([2], dtype=np.int64)
+
+        with pytest.raises(ValueError):
+            select_top_k_circles(circles, fitting_losses, k=1, batch_lengths=batch_lengths)

--- a/test/test_circle_detection.py
+++ b/test/test_circle_detection.py
@@ -143,22 +143,24 @@ class TestCircleDetection:
         xy = self._generate_circle_points(
             original_circles, min_points=100, max_points=100, variance=np.array([0, 0.05])
         )
-        bandwidth = 0.05
+        bandwidth = 0.07
 
-        detected_circles, fitting_losses = detect_circles(xy, bandwidth=bandwidth, max_circles=1)
+        detected_circles, fitting_losses, batch_lengths_circles = detect_circles(xy, bandwidth=bandwidth, max_circles=1)
 
         assert len(detected_circles) == 1
         assert len(fitting_losses) == 1
+        np.testing.assert_array_equal(batch_lengths_circles, np.array([1], dtype=np.int64))
 
         # the first circle is expected to be returned because its points have lower variance
-        np.testing.assert_array_equal(original_circles[0], detected_circles[0])
+        np.testing.assert_almost_equal(original_circles[0], detected_circles[0], decimal=10)
 
-        detected_circles, fitting_losses = detect_circles(
+        detected_circles, fitting_losses, batch_lengths_circles = detect_circles(
             xy, bandwidth=bandwidth, max_circles=2, non_maximum_suppression=True
         )
 
         assert len(detected_circles) == 2
         assert len(fitting_losses) == 2
+        np.testing.assert_array_equal(batch_lengths_circles, np.array([2], dtype=np.int64))
 
         expected_fitting_losses = []
         for circle in detected_circles:
@@ -166,7 +168,7 @@ class TestCircleDetection:
             expected_loss = -1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2)
             expected_fitting_losses.append(expected_loss.sum())
 
-        assert (np.abs(original_circles - detected_circles) < 0.03).all()
+        assert (np.abs(original_circles - detected_circles) < 0.01).all()
         np.testing.assert_almost_equal(expected_fitting_losses, fitting_losses, decimal=5)
 
     def test_several_noisy_circles(self):
@@ -182,7 +184,7 @@ class TestCircleDetection:
         min_start_xy = xy.min(axis=0) - 2
         max_start_xy = xy.max(axis=0) + 2
 
-        detected_circles, fitting_losses = detect_circles(
+        detected_circles, fitting_losses, batch_lengths_circles = detect_circles(
             xy,
             bandwidth=0.05,
             min_start_x=min_start_xy[0],
@@ -208,6 +210,7 @@ class TestCircleDetection:
 
         assert len(original_circles) == len(detected_circles)
         assert len(detected_circles) == len(fitting_losses)
+        np.testing.assert_array_equal(batch_lengths_circles, np.array([len(original_circles)], dtype=np.int64))
 
         for original_circle in original_circles:
             matches_with_detected_circle = False
@@ -218,23 +221,77 @@ class TestCircleDetection:
 
             assert matches_with_detected_circle
 
+    @pytest.mark.parametrize("pass_max_dist", [True, False])
+    def test_filtering_circumferential_completeness_index(self, pass_max_dist: bool):
+        original_circles = np.array([[0, 0, 0.5]])
+        xy = self._generate_circle_points(original_circles, min_points=100, max_points=100, variance=0)
+        bandwidth = 0.01
+
+        max_dist = None
+        if pass_max_dist:
+            max_dist = bandwidth
+
+        detected_circles, fitting_losses, _ = detect_circles(
+            xy,
+            bandwidth=bandwidth,
+            max_circles=1,
+            min_circumferential_completeness_idx=0.9,
+            circumferential_completeness_idx_max_dist=max_dist,
+            circumferential_completeness_idx_num_regions=int(365 / 5),
+        )
+
+        assert len(detected_circles) == 1
+        assert len(fitting_losses) == 1
+
+        np.testing.assert_almost_equal(original_circles[0], detected_circles[0], decimal=10)
+
+        detected_circles, fitting_losses, _ = detect_circles(
+            xy[:50],
+            bandwidth=bandwidth,
+            max_circles=1,
+            min_circumferential_completeness_idx=0.9,
+            circumferential_completeness_idx_max_dist=max_dist,
+            circumferential_completeness_idx_num_regions=int(365 / 5),
+        )
+
+        assert len(detected_circles) == 0
+        assert len(fitting_losses) == 0
+
     def test_batch_processing(self):
         original_circles = np.array([[0, 0, 0.5], [0, 0, 0.52]])
         xy_1 = self._generate_circle_points(original_circles[:1], min_points=100, max_points=100, variance=0.0)
         xy_2 = self._generate_circle_points(original_circles[1:], min_points=100, max_points=100, variance=0.0)
-        batch_indices = np.split(np.arange(len(xy_1) + len(xy_2), dtype=np.int64), 2)
+        batch_lengths = np.array([len(xy_1), len(xy_2)], dtype=np.int64)
         bandwidth = 0.05
 
-        detected_circles, fitting_losses = detect_circles(
-            np.concatenate((xy_1, xy_2)), bandwidth=bandwidth, batch_indices=batch_indices, max_circles=1
+        detected_circles, fitting_losses, batch_lengths_circles = detect_circles(
+            np.concatenate((xy_1, xy_2)),
+            bandwidth=bandwidth,
+            batch_lengths=batch_lengths,
+            max_circles=1,
         )
 
-        num_batches = len(batch_indices)
+        num_batches = len(batch_lengths)
         assert len(detected_circles) == num_batches
         assert len(fitting_losses) == num_batches
 
+        batch_starts = np.cumsum(np.concatenate((np.array([0]), batch_lengths_circles)))[:-1]
+
         for batch_idx in range(num_batches):
-            np.testing.assert_almost_equal(original_circles[batch_idx], detected_circles[batch_idx][0], decimal=5)
+            batch_start = batch_starts[batch_idx]
+            batch_end = batch_start + batch_lengths_circles[batch_idx]
+            np.testing.assert_almost_equal(
+                original_circles[batch_idx].reshape(-1, 3), detected_circles[batch_start:batch_end], decimal=5
+            )
+
+    def test_empty_input(self):
+        xy = np.empty((0, 2), dtype=np.float64)
+        bandwidth = 0.05
+        detected_circles, fitting_losses, batch_lengths_circles = detect_circles(xy, bandwidth)
+
+        assert len(detected_circles) == 0
+        assert len(fitting_losses) == 0
+        assert batch_lengths_circles.sum() == 0
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -258,6 +315,8 @@ class TestCircleDetection:
             {"armijo_min_decrease_percentage": -1},
             {"armijo_min_decrease_percentage": 2},
             {"deduplication_precision": -2},
+            {"min_circumferential_completeness_idx": 0.5, "circumferential_completeness_idx_num_regions": None},
+            {"batch_lengths": np.array([], dtype=np.int64)},
         ],
     )
     def test_invalid_parameters(self, kwargs: Dict[str, Any]):


### PR DESCRIPTION
This pull request extends the interface of the package to support batch processing, i.e., processing multiple sets of points or multiple sets of circles in parallel. For this purpose, parameters to specify the number of points or circles in the individual batch items are added to the methods that support batch processing (e.g., `batch_lengths: numpy.NDArray[np.int64]`). The return types are extended to include the corresponding information for the output batches.

BREAKING CHANGE:
- The return type of `circle_detection.detect_circles` is changed from `Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]` to `Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64]]`.
- The order of the parameters `min_circumferential_completeness_index` and `num_regions` in `circle_detection.operations.filter_circumferential_completeness_index` is swapped.
- The return type of `circle_detection.operations.filter_circumferential_completeness_index` is changed from `Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64]]` to `Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]`
- The return type of `circle_detection.operations.non_maximum_suppression` is changed from `Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]` to `Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]`.