### PR TITLE
feat: add num_workers parameter to multi-threaded functions

### DIFF
--- a/src/circle_detection/_circle_detection.py
+++ b/src/circle_detection/_circle_detection.py
@@ -49,6 +49,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
     circumferential_completeness_idx_max_dist: Optional[float] = None,
     circumferential_completeness_idx_num_regions: Optional[int] = None,
     non_maximum_suppression: bool = True,
+    num_workers: int = 1,
 ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64]]:
     r"""
     Detects circles in a set of 2D points using the M-estimator method proposed in `Garlipp, Tim, and Christine
@@ -274,6 +275,8 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         non_maximum_suppression: Whether non-maximum suppression should be applied to the detected circles. If this
             option is enabled, circles that overlap with other circles, are only kept if they have the lowest fitting
             loss among the circles with which they overlap. Defaults to :code:`True`.
+        num_workers: Number of workers threads to use for parallel processing. If set to -1, all CPU threads are used.
+            Defaults to 1.
 
     Returns:
         : Tuple of three arrays. The first array contains the parameters of the detected circles (in the following
@@ -518,6 +521,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
         float(armijo_min_decrease_percentage),
         float(min_step_size),
         float(min_fitting_score),
+        int(num_workers),
     )
 
     detected_circles, batch_lengths_circles, selected_indices = deduplicate_circles(
@@ -527,7 +531,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
 
     if non_maximum_suppression and (max_circles is None or max_circles > 1):
         detected_circles, fitting_losses, batch_lengths_circles, _ = non_maximum_suppression_op(
-            detected_circles, fitting_losses, batch_lengths_circles
+            detected_circles, fitting_losses, batch_lengths_circles, num_workers=num_workers
         )
 
     if min_circumferential_completeness_idx is not None:
@@ -541,6 +545,7 @@ def detect_circles(  # pylint: disable=too-many-arguments, too-many-positional-a
             max_dist=circumferential_completeness_idx_max_dist,
             batch_lengths_circles=batch_lengths_circles,
             batch_lengths_xy=batch_lengths,
+            num_workers=num_workers,
         )
         fitting_losses = fitting_losses[selected_indices]
 

--- a/src/circle_detection/operations/_circumferential_completeness_index.py
+++ b/src/circle_detection/operations/_circumferential_completeness_index.py
@@ -23,6 +23,7 @@ def circumferential_completeness_index(
     max_dist: Optional[float] = None,
     batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
     batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
+    num_workers: int = 1,
 ) -> npt.NDArray[np.float64]:
     r"""
     Calculates the circumferential completeness indices of the specified circles. The circumferential completeness index
@@ -57,6 +58,8 @@ def circumferential_completeness_index(
             expected that all points belonging to the same batch item are stored consecutively in the :code:`xy`
             input array. If :code:`batch_lengths_xy` is set to :code:`None`, it is assumed that the input points
             belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
+        num_workers: Number of workers threads to use for parallel processing. If set to -1, all CPU threads are used.
+            Defaults to 1.
 
     Returns:
         Circumferential completeness indices of the circles.
@@ -94,7 +97,7 @@ def circumferential_completeness_index(
         max_dist = -1
 
     return circumferential_completeness_index_cpp(
-        circles, xy, batch_lengths_circles, batch_lengths_xy, int(num_regions), float(max_dist)
+        circles, xy, batch_lengths_circles, batch_lengths_xy, int(num_regions), float(max_dist), int(num_workers)
     )
 
 
@@ -106,6 +109,7 @@ def filter_circumferential_completeness_index(
     max_dist: Optional[float] = None,
     batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
     batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
+    num_workers: int = 1,
 ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Filters out the circles whose circumferential completeness index is below the specified minimum circumferential
@@ -134,6 +138,8 @@ def filter_circumferential_completeness_index(
             expected that all points belonging to the same batch item are stored consecutively in the :code:`xy`
             input array. If :code:`batch_lengths_xy` is set to :code:`None`, it is assumed that the input points
             belong to a single batch item and batch processing is disabled. Defaults to :code:`None`.
+        num_workers: Number of workers threads to use for parallel processing. If set to -1, all CPU threads are used.
+            Defaults to 1.
 
     Returns:
         : Tuple of three arrays. The first contains the parameters of the circles remaining after filtering.
@@ -179,4 +185,5 @@ def filter_circumferential_completeness_index(
         int(num_regions),
         float(max_dist),
         float(min_circumferential_completeness_index),
+        int(num_workers),
     )

--- a/src/circle_detection/operations/_non_maximum_suppression.py
+++ b/src/circle_detection/operations/_non_maximum_suppression.py
@@ -16,6 +16,7 @@ def non_maximum_suppression(
     circles: npt.NDArray[np.float64],
     fitting_losses: npt.NDArray[np.float64],
     batch_lengths: Optional[npt.NDArray[np.int64]] = None,
+    num_workers: int = 1,
 ) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Non-maximum suppression operation to remove overlapping circles. If a circle overlaps with other circles, it is
@@ -34,6 +35,8 @@ def non_maximum_suppression(
             contain the circles of the first batch item and :code:`circles[N_1:]` the circles of the second batch item.
             If :code:`batch_lengths` is set to :code:`None`, it is assumed that the input circles belong to a single
             batch item and batch processing is disabled. Defaults to :code:`None`.
+        num_workers: Number of workers threads to use for parallel processing. If set to -1, all CPU threads are used.
+            Defaults to 1.
 
     Returns:
         : Tuple of four arrays. The first contains the parameters of the circles remaining after non-maximum
@@ -60,4 +63,4 @@ def non_maximum_suppression(
     if batch_lengths is None:
         batch_lengths = np.array([len(circles)], dtype=np.int64)
 
-    return non_maximum_suppression_cpp(circles, fitting_losses, batch_lengths)
+    return non_maximum_suppression_cpp(circles, fitting_losses, batch_lengths, int(num_workers))


### PR DESCRIPTION
This pull request adds a `num_workers` parameter to those functions that use multi-threading. Using this parameter the user can explicitly control the number of threads, while the default number of threads of OpenMP was used before.