### PR TITLE
fix: deduplicate_circles

### DIFF
--- a/src/circle_detection/operations/_deduplicate_circles.py
+++ b/src/circle_detection/operations/_deduplicate_circles.py
@@ -73,10 +73,11 @@ def deduplicate_circles(
 
     unique_rounded_circles, selected_indices = np.unique(rounded_circles, return_index=True, axis=0)
 
-    batch_item_borders_mask = np.empty(len(unique_rounded_circles), dtype=np.bool)
+    batch_item_borders_mask = np.empty(len(unique_rounded_circles), dtype=bool)
     batch_item_borders_mask[:1] = True
     batch_item_borders_mask[1:] = unique_rounded_circles[1:, 0] != unique_rounded_circles[:-1, 0]
-    deduplicated_batch_lengths = np.diff(
+    deduplicated_batch_lengths = np.zeros(len(batch_lengths), dtype=np.int64)
+    deduplicated_batch_lengths[batch_lengths > 0] = np.diff(
         np.concatenate(np.nonzero(batch_item_borders_mask) + ([len(batch_item_borders_mask)],))
     )
 

--- a/test/operations/test_deduplicate_circles.py
+++ b/test/operations/test_deduplicate_circles.py
@@ -28,10 +28,10 @@ class TestDeduplicateCircles:
         circles = np.array(
             [[0, 0, 1], [1, 0, 1], [0, 0, 1.01], [0, 0, 1], [2, 2, 2], [1, 1, 1], [1, 1, 1]], dtype=np.float64
         )
-        batch_lengths = np.array([4, 3], dtype=np.int64)
+        batch_lengths = np.array([4, 0, 3], dtype=np.int64)
 
         expected_deduplicated_circles = np.array([[0, 0, 1], [1, 0, 1], [1, 1, 1], [2, 2, 2]], dtype=np.float64)
-        expected_deduplicated_batch_lengths = np.array([2, 2], dtype=np.int64)
+        expected_deduplicated_batch_lengths = np.array([2, 0, 2], dtype=np.int64)
 
         deduplication_precision = 1
 


### PR DESCRIPTION
This pull request fixes the following issues in the `circle_detection.operations.deduplicate_circles` method:

- `bool` is used instead of `numpy.bool` for creating numpy arrays of boolean type, as the latter does not work for numpy versions < 2
- the method has been adapted to handle empty batch items correctly 