### PR TITLE
fix: circle deduplication

### DIFF
--- a/src/circle_detection/operations/_deduplicate_circles.py
+++ b/src/circle_detection/operations/_deduplicate_circles.py
@@ -67,7 +67,7 @@ def deduplicate_circles(
         return circles[selected_indices], np.array([len(unique_rounded_circles)], dtype=np.int64), selected_indices
 
     # add batch indices as first dimension to separate circles from different batch items
-    rounded_circles = np.empty((len(circles), 4), dtype=np.int64)
+    rounded_circles = np.empty((len(circles), 4), dtype=np.float64)
     rounded_circles[:, 0] = np.repeat(np.arange(len(batch_lengths), dtype=np.float64), batch_lengths)
     rounded_circles[:, 1:] = np.round(circles, decimals=deduplication_precision)
 

--- a/test/operations/test_deduplicate_circles.py
+++ b/test/operations/test_deduplicate_circles.py
@@ -61,9 +61,9 @@ class TestDeduplicateCircles:
         np.testing.assert_array_equal(expected_deduplicated_batch_lengths, deduplicated_batch_lengths)
 
     @pytest.mark.parametrize("deduplication_precision", [1, 4])
-    def test_rounding_precision(self, deduplication_precision: int):
-        circles = np.array([[0, 0, 1], [0.0001, 0.0001, 0.9999]], dtype=np.float64)
-        batch_lengths = np.array([2], dtype=np.int64)
+    def test_rounding_precision_single_batch_item(self, deduplication_precision: int):
+        circles = np.array([[0, 0, 1], [0.0001, 0.0001, 0.9999], [0, 0, 1.001]], dtype=np.float64)
+        batch_lengths = np.array([3], dtype=np.int64)
 
         deduplicated_circles, _, _ = deduplicate_circles(
             circles, deduplication_precision=deduplication_precision, batch_lengths=batch_lengths
@@ -71,6 +71,22 @@ class TestDeduplicateCircles:
 
         if deduplication_precision < 4:
             assert len(deduplicated_circles) == 1
+        else:
+            assert len(deduplicated_circles) == len(circles)
+
+    @pytest.mark.parametrize("deduplication_precision", [1, 4])
+    def test_rounding_precision_batch_processing(self, deduplication_precision: int):
+        batch_size = 2
+        circles = np.array([[[0, 0, 1], [0.0001, 0.0001, 0.9999], [0, 0, 1.001]]], dtype=np.float64)
+        circles = np.repeat(circles, batch_size, axis=0).reshape(-1, 3)
+        batch_lengths = np.array([3] * batch_size, dtype=np.int64)
+
+        deduplicated_circles, _, _ = deduplicate_circles(
+            circles, deduplication_precision=deduplication_precision, batch_lengths=batch_lengths
+        )
+
+        if deduplication_precision < 4:
+            assert len(deduplicated_circles) == batch_size
         else:
             assert len(deduplicated_circles) == len(circles)
 


### PR DESCRIPTION
This pull request fixes the following bug in the `circle_detection.operations.deduplicate_circles` method: For rounding the circle parameters, a numpy array of type `numpy.int64` was used instead of `numpy.float64`.