### PR TITLE
refactor: support variable array data types

### DIFF
--- a/csrc/include/CircleDetection/circle_detection_m_estimator.h
+++ b/csrc/include/CircleDetection/circle_detection_m_estimator.h
@@ -100,7 +100,8 @@ detect_circles_m_estimator(
       Eigen::Array<scalar_T, Eigen::Dynamic, 1> offset = current_xy.colwise().mean();
       offsets(batch_idx, Eigen::all) = offset;
 
-      xy(Eigen::seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all) = current_xy.rowwise() - offsets(batch_idx, Eigen::all);
+      xy(Eigen::seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all) =
+          current_xy.rowwise() - offsets(batch_idx, Eigen::all);
       min_start_x(batch_idx) = (min_start_x(batch_idx) - offset(0));
       max_start_x(batch_idx) = (max_start_x(batch_idx) - offset(0));
       min_start_y(batch_idx) = (min_start_y(batch_idx) - offset(1));
@@ -176,8 +177,7 @@ detect_circles_m_estimator(
               Eigen::Array<scalar_T, Eigen::Dynamic, 1> squared_dists_to_center =
                   (current_xy.matrix().rowwise() - center).rowwise().squaredNorm().array();
               Eigen::Array<scalar_T, Eigen::Dynamic, 1> dists_to_center = squared_dists_to_center.array().sqrt();
-              Eigen::Array<scalar_T, Eigen::Dynamic, 1> scaled_residuals =
-                  (dists_to_center - radius) / bandwidth;
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> scaled_residuals = (dists_to_center - radius) / bandwidth;
               fitting_loss = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).mean();
 
               // first derivative of the outer term of the loss function
@@ -204,8 +204,8 @@ detect_circles_m_estimator(
                    1 / dists_to_center.replicate(1, 2));
               // this array stores the derivatives dxdy and dydx in one column (both are identical)
               Eigen::Array<scalar_T, Eigen::Dynamic, 1> inner_derivative_2_x_y =
-                  -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) *
-                  (current_xy.col(0) - center[0]) * (current_xy.col(1) - center[1]);
+                  -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) * (current_xy.col(0) - center[0]) *
+                  (current_xy.col(1) - center[1]);
 
               // first derivatives of the entire loss function with respect to the circle parameters
               Eigen::RowVector<scalar_T, 2> derivative_xy =
@@ -279,7 +279,8 @@ detect_circles_m_estimator(
                   auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
                   auto next_radius = radius + (next_step_size * step_direction[2]);
                   Eigen::Array<scalar_T, Eigen::Dynamic, 1> next_scaled_residuals =
-                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
+                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
+                      bandwidth;
                   next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).mean();
                 }
               }
@@ -301,7 +302,8 @@ detect_circles_m_estimator(
                   auto next_center = center + (step_size * step_direction.head(2)).matrix().transpose();
                   auto next_radius = radius + (step_size * step_direction[2]);
                   Eigen::Array<scalar_T, Eigen::Dynamic, 1> next_scaled_residuals =
-                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
+                      ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
+                      bandwidth;
                   auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).mean();
                   fitting_score = -1 * next_loss / bandwidth;
 
@@ -325,8 +327,7 @@ detect_circles_m_estimator(
                 break;
               }
 
-              if ((std::abs(radius_update) < break_min_change) &&
-                  (std::abs(center_update[0]) < break_min_change) &&
+              if ((std::abs(radius_update) < break_min_change) && (std::abs(center_update[0]) < break_min_change) &&
                   (std::abs(center_update[1]) < break_min_change)) {
                 break;
               }

--- a/csrc/include/CircleDetection/circle_detection_m_estimator.h
+++ b/csrc/include/CircleDetection/circle_detection_m_estimator.h
@@ -12,22 +12,24 @@
 #ifndef CIRCLE_DETECTION_M_ESTIMATOR_H
 #define CIRCLE_DETECTION_M_ESTIMATOR_H
 
-namespace {
-
-using namespace Eigen;
-using ArrayXb = Eigen::Array<bool, Eigen::Dynamic, 1>;
-using ArrayXl = Eigen::Array<int64_t, Eigen::Dynamic, 1>;
-
-}  // namespace
-
 namespace CircleDetection {
-std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
-    ArrayX2d xy, ArrayXl batch_lengths, double bandwidth, ArrayXd min_start_x, ArrayXd max_start_x, int n_start_x,
-    ArrayXd min_start_y, ArrayXd max_start_y, int n_start_y, ArrayXd min_start_radius, ArrayXd max_start_radius,
-    int n_start_radius, ArrayXd break_min_x, ArrayXd break_max_x, ArrayXd break_min_y, ArrayXd break_max_y,
-    ArrayXd break_min_radius, ArrayXd break_max_radius, double break_min_change = 1e-5, int max_iterations = 1000,
-    double acceleration_factor = 1.6, double armijo_attenuation_factor = 0.7,
-    double armijo_min_decrease_percentage = 0.5, double min_step_size = 1e-20, double min_fitting_score = 1e-6,
+
+template <typename scalar_T>
+std::tuple<Eigen::Array<scalar_T, Eigen::Dynamic, 3>, Eigen::Array<scalar_T, Eigen::Dynamic, 1>,
+           Eigen::Array<int64_t, Eigen::Dynamic, 1>>
+detect_circles_m_estimator(
+    Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy, Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths,
+    scalar_T bandwidth, Eigen::Array<scalar_T, Eigen::Dynamic, 1> min_start_x,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> max_start_x, int n_start_x,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> min_start_y, Eigen::Array<scalar_T, Eigen::Dynamic, 1> max_start_y,
+    int n_start_y, Eigen::Array<scalar_T, Eigen::Dynamic, 1> min_start_radius,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> max_start_radius, int n_start_radius,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_x, Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_x,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_y, Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_y,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_radius,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_radius, scalar_T break_min_change = 1e-5,
+    int max_iterations = 1000, scalar_T acceleration_factor = 1.6, scalar_T armijo_attenuation_factor = 0.7,
+    scalar_T armijo_min_decrease_percentage = 0.5, scalar_T min_step_size = 1e-20, scalar_T min_fitting_score = 1e-6,
     int num_workers = 1) {
   if (xy.rows() != batch_lengths.sum()) {
     throw std::invalid_argument("The number of points must be equal to the sum of batch_lengths");
@@ -78,7 +80,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
   auto num_batches = batch_lengths.rows();
 
-  ArrayXl batch_starts(num_batches);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_starts(num_batches);
 
   int64_t batch_start = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
@@ -86,22 +88,27 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
     batch_start += batch_lengths(batch_idx);
   }
 
-  ArrayXd start_radii(num_batches * n_start_radius);
-  ArrayXd start_centers_x(num_batches * n_start_x);
-  ArrayXd start_centers_y(num_batches * n_start_y);
-  double eps = 0.01 * min_step_size;
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> start_radii(num_batches * n_start_radius);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> start_centers_x(num_batches * n_start_x);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> start_centers_y(num_batches * n_start_y);
+  scalar_T eps = 0.01 * min_step_size;
 
 #pragma omp parallel for num_threads(num_workers)
   for (int64_t i = 0; i < num_batches; ++i) {
     start_radii.segment(i * n_start_radius, n_start_radius) =
-        ArrayXd::LinSpaced(n_start_radius, min_start_radius(i), max_start_radius(i));
-    start_centers_x(seqN(i * n_start_x, n_start_x)) = ArrayXd::LinSpaced(n_start_x, min_start_x(i), max_start_x(i));
-    start_centers_y(seqN(i * n_start_y, n_start_y)) = ArrayXd::LinSpaced(n_start_y, min_start_y(i), max_start_y(i));
+        Eigen::Array<scalar_T, Eigen::Dynamic, 1>::LinSpaced(n_start_radius, min_start_radius(i), max_start_radius(i));
+    start_centers_x(Eigen::seqN(i * n_start_x, n_start_x)) =
+        Eigen::Array<scalar_T, Eigen::Dynamic, 1>::LinSpaced(n_start_x, min_start_x(i), max_start_x(i));
+    start_centers_y(Eigen::seqN(i * n_start_y, n_start_y)) =
+        Eigen::Array<scalar_T, Eigen::Dynamic, 1>::LinSpaced(n_start_y, min_start_y(i), max_start_y(i));
   }
 
-  ArrayX3d fitted_circles = ArrayX3d::Constant(num_batches * n_start_radius * n_start_x * n_start_y, 3, -1);
-  ArrayXb fitting_converged = ArrayXb::Zero(num_batches * n_start_radius * n_start_x * n_start_y);
-  ArrayXd fitting_scores = ArrayXd::Constant(num_batches * n_start_radius * n_start_x * n_start_y, 0);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 3> fitted_circles =
+      Eigen::Array<scalar_T, Eigen::Dynamic, 3>::Constant(num_batches * n_start_radius * n_start_x * n_start_y, 3, -1);
+  Eigen::Array<bool, Eigen::Dynamic, 1> fitting_converged =
+      Eigen::Array<bool, Eigen::Dynamic, 1>::Zero(num_batches * n_start_radius * n_start_x * n_start_y);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> fitting_scores =
+      Eigen::Array<scalar_T, Eigen::Dynamic, 1>::Constant(num_batches * n_start_radius * n_start_x * n_start_y, 0);
 
 #pragma omp parallel num_threads(num_workers)
 #pragma omp single
@@ -124,9 +131,9 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
 #pragma omp task
           {
-            ArrayX2d current_xy;
+            Eigen::Array<scalar_T, Eigen::Dynamic, 2> current_xy;
             if (num_batches > 1) {
-              current_xy = xy(seqN(batch_starts(idx_batch), batch_lengths(idx_batch)), Eigen::all);
+              current_xy = xy(Eigen::seqN(batch_starts(idx_batch), batch_lengths(idx_batch)), Eigen::all);
             } else {
               current_xy = xy;
             }
@@ -136,102 +143,107 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
             auto start_center_x = start_centers_x[idx_batch * n_start_x + idx_x];
             auto start_center_y = start_centers_y[idx_batch * n_start_y + idx_y];
-            RowVector2d center(start_center_x, start_center_y);
+            Eigen::RowVector<scalar_T, 2> center(start_center_x, start_center_y);
 
-            double fitting_loss = 0;
-            double fitting_score = 0;
+            scalar_T fitting_loss = 0;
+            scalar_T fitting_score = 0;
             bool diverged = false;
 
             for (int iteration = 0; iteration < max_iterations; ++iteration) {
-              ArrayXd squared_dists_to_center =
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> squared_dists_to_center =
                   (current_xy.matrix().rowwise() - center).rowwise().squaredNorm().array();
-              ArrayXd dists_to_center = squared_dists_to_center.array().sqrt();
-              ArrayXd scaled_residuals = (dists_to_center - radius) / bandwidth;
-              fitting_loss = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> dists_to_center = squared_dists_to_center.array().sqrt();
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> scaled_residuals = (dists_to_center - radius) / bandwidth;
+              fitting_loss = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).sum();
 
               // first derivative of the outer term of the loss function
-              ArrayXd outer_derivative_1 =
-                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_1_scalar<double>);
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> outer_derivative_1 =
+                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_1_scalar<scalar_T>);
 
               // second derivative of the outer term of the loss function
-              ArrayXd outer_derivative_2 =
-                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_2_scalar<double>);
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> outer_derivative_2 =
+                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_2_scalar<scalar_T>);
 
               // first derivative of the inner term of the loss function
               // this array stores the derivatives dx and dy in different columns
-              ArrayX2d inner_derivative_1_x = (-1 / (bandwidth * dists_to_center)).replicate(1, 2) *
-                                              (current_xy.matrix().rowwise() - center).array();
-              double inner_derivative_1_r = -1 / bandwidth;
+              Eigen::Array<scalar_T, Eigen::Dynamic, 2> inner_derivative_1_x =
+                  (-1 / (bandwidth * dists_to_center)).replicate(1, 2) *
+                  (current_xy.matrix().rowwise() - center).array();
+              scalar_T inner_derivative_1_r = -1 / bandwidth;
 
               // second derivative of the inner term of the loss function
               // this array stores the derivatives dxdx and dydy in different columns
-              ArrayX2d inner_derivative_2_x_x = 1 / bandwidth *
-                                                (-1 / (squared_dists_to_center * dists_to_center).replicate(1, 2) *
-                                                     (current_xy.matrix().rowwise() - center).array().square() +
-                                                 1 / dists_to_center.replicate(1, 2));
+              Eigen::Array<scalar_T, Eigen::Dynamic, 2> inner_derivative_2_x_x =
+                  1 / bandwidth *
+                  (-1 / (squared_dists_to_center * dists_to_center).replicate(1, 2) *
+                       (current_xy.matrix().rowwise() - center).array().square() +
+                   1 / dists_to_center.replicate(1, 2));
               // this array stores the derivatives dxdy and dydx in one column (both are identical)
-              ArrayXd inner_derivative_2_x_y = -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) *
-                                               (current_xy.col(0) - center[0]) * (current_xy.col(1) - center[1]);
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> inner_derivative_2_x_y =
+                  -1 / bandwidth * 1 / (squared_dists_to_center * dists_to_center) * (current_xy.col(0) - center[0]) *
+                  (current_xy.col(1) - center[1]);
 
               // first derivatives of the entire loss function with respect to the circle parameters
-              RowVector2d derivative_xy =
+              Eigen::RowVector<scalar_T, 2> derivative_xy =
                   (outer_derivative_1.replicate(1, 2) * inner_derivative_1_x).matrix().colwise().sum();
-              double derivative_r = (outer_derivative_1 * inner_derivative_1_r).matrix().sum();
-              Vector3d gradient(derivative_xy[0], derivative_xy[1], derivative_r);
+              scalar_T derivative_r = (outer_derivative_1 * inner_derivative_1_r).matrix().sum();
+              Eigen::Vector<scalar_T, 3> gradient(derivative_xy[0], derivative_xy[1], derivative_r);
 
               // second derivatives of the entire loss function with respect to the circle parameters
-              double derivative_x_x = ((outer_derivative_2 * inner_derivative_1_x.col(0).square()) +
-                                       (outer_derivative_1 * inner_derivative_2_x_x.col(0)))
-                                          .matrix()
-                                          .sum();
-              double derivative_x_y =
+              scalar_T derivative_x_x = ((outer_derivative_2 * inner_derivative_1_x.col(0).square()) +
+                                         (outer_derivative_1 * inner_derivative_2_x_x.col(0)))
+                                            .matrix()
+                                            .sum();
+              scalar_T derivative_x_y =
                   ((outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_x.col(0)) +
                    (outer_derivative_1 * inner_derivative_2_x_y))
                       .matrix()
                       .sum();
-              double derivative_x_r =
+              scalar_T derivative_x_r =
                   (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(0)).matrix().sum();
 
-              double derivative_y_x =
+              scalar_T derivative_y_x =
                   ((outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_x.col(1)) +
                    (outer_derivative_1 * inner_derivative_2_x_y))
                       .matrix()
                       .sum();
-              double derivative_y_y = ((outer_derivative_2 * inner_derivative_1_x.col(1).square()) +
-                                       (outer_derivative_1 * inner_derivative_2_x_x.col(1)))
-                                          .matrix()
-                                          .sum();
-              double derivative_y_r =
+              scalar_T derivative_y_y = ((outer_derivative_2 * inner_derivative_1_x.col(1).square()) +
+                                         (outer_derivative_1 * inner_derivative_2_x_x.col(1)))
+                                            .matrix()
+                                            .sum();
+              scalar_T derivative_y_r =
                   (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_x.col(1)).matrix().sum();
 
-              double derivative_r_x =
+              scalar_T derivative_r_x =
                   (outer_derivative_2 * inner_derivative_1_x.col(0) * inner_derivative_1_r).matrix().sum();
-              double derivative_r_y =
+              scalar_T derivative_r_y =
                   (outer_derivative_2 * inner_derivative_1_x.col(1) * inner_derivative_1_r).matrix().sum();
-              double derivative_r_r = (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_r).matrix().sum();
+              scalar_T derivative_r_r =
+                  (outer_derivative_2 * inner_derivative_1_r * inner_derivative_1_r).matrix().sum();
 
-              Matrix3d hessian(3, 3);
+              Eigen::Matrix<scalar_T, Eigen::Dynamic, 3> hessian(3, 3);
               hessian << derivative_x_x, derivative_x_y, derivative_x_r, derivative_y_x, derivative_y_y, derivative_y_r,
                   derivative_r_x, derivative_r_y, derivative_r_r;
 
-              double determinant_hessian = hessian.determinant();
+              scalar_T determinant_hessian = hessian.determinant();
 
-              double determinant_hessian_submatrix = derivative_x_x * derivative_y_y - derivative_x_y * derivative_y_x;
+              scalar_T determinant_hessian_submatrix =
+                  derivative_x_x * derivative_y_y - derivative_x_y * derivative_y_x;
 
-              double step_size = 1.0;
-              ArrayXd step_direction(3);
+              scalar_T step_size = 1.0;
+              Eigen::Array<scalar_T, Eigen::Dynamic, 1> step_direction(3);
               if ((determinant_hessian > 0) && (determinant_hessian_submatrix > 0)) {
                 step_direction = -1 * (hessian.inverse() * gradient).array();
               } else {
                 step_direction = -1 * gradient;
 
                 // step size acceleration
-                double next_step_size = 1.0;
+                scalar_T next_step_size = 1.0;
                 auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
                 auto next_radius = radius + (next_step_size * step_direction[2]);
-                ArrayXd next_scaled_residuals =
+                Eigen::Array<scalar_T, Eigen::Dynamic, 1> next_scaled_residuals =
                     ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
-                auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
+                auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).sum();
                 auto previous_loss = fitting_loss;
 
                 while (next_loss < previous_loss) {
@@ -242,10 +254,10 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
                   auto next_center = center + (next_step_size * step_direction.head(2)).matrix().transpose();
                   auto next_radius = radius + (next_step_size * step_direction[2]);
-                  ArrayXd next_scaled_residuals =
+                  Eigen::Array<scalar_T, Eigen::Dynamic, 1> next_scaled_residuals =
                       ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
                       bandwidth;
-                  next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
+                  next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).sum();
                 }
               }
 
@@ -256,8 +268,8 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
                 // to avoid initializing all variables of the while loop before, actual_loss_decrease is set to 0
                 // and expected_loss_decrease to 1 so that the loop is executed at least once and the variables are
                 // properly initialized in the first iteration of the loop
-                double actual_loss_decrease = 0.0;
-                double expected_loss_decrease = 1.0;
+                scalar_T actual_loss_decrease = 0.0;
+                scalar_T expected_loss_decrease = 1.0;
                 step_size = 1 / armijo_attenuation_factor;
 
                 while (expected_loss_decrease - actual_loss_decrease > eps && step_size > min_step_size) {
@@ -265,10 +277,10 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
                   auto next_center = center + (step_size * step_direction.head(2)).matrix().transpose();
                   auto next_radius = radius + (step_size * step_direction[2]);
-                  ArrayXd next_scaled_residuals =
+                  Eigen::Array<scalar_T, Eigen::Dynamic, 1> next_scaled_residuals =
                       ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
                       bandwidth;
-                  auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
+                  auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<scalar_T>).sum();
                   fitting_score = -1 * next_loss / bandwidth;
 
                   actual_loss_decrease = fitting_loss - next_loss;
@@ -314,7 +326,8 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
 
 #pragma omp taskwait
 
-  ArrayXl batch_lengths_circles = ArrayXl::Constant(num_batches, 0);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_circles =
+      Eigen::Array<int64_t, Eigen::Dynamic, 1>::Constant(num_batches, 0);
   std::vector<int64_t> converged_indices;
 
   for (int64_t i = 0; i < fitted_circles.rows(); ++i) {

--- a/csrc/include/CircleDetection/circle_detection_m_estimator.h
+++ b/csrc/include/CircleDetection/circle_detection_m_estimator.h
@@ -147,13 +147,15 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
                   (current_xy.matrix().rowwise() - center).rowwise().squaredNorm().array();
               ArrayXd dists_to_center = squared_dists_to_center.array().sqrt();
               ArrayXd scaled_residuals = (dists_to_center - radius) / bandwidth;
-              fitting_loss = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar).sum();
+              fitting_loss = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
 
               // first derivative of the outer term of the loss function
-              ArrayXd outer_derivative_1 = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_1_scalar);
+              ArrayXd outer_derivative_1 =
+                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_1_scalar<double>);
 
               // second derivative of the outer term of the loss function
-              ArrayXd outer_derivative_2 = scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_2_scalar);
+              ArrayXd outer_derivative_2 =
+                  scaled_residuals.unaryExpr(&CircleDetection::loss_fn_derivative_2_scalar<double>);
 
               // first derivative of the inner term of the loss function
               // this array stores the derivatives dx and dy in different columns
@@ -229,7 +231,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
                 auto next_radius = radius + (next_step_size * step_direction[2]);
                 ArrayXd next_scaled_residuals =
                     ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) / bandwidth;
-                auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar).sum();
+                auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
                 auto previous_loss = fitting_loss;
 
                 while (next_loss < previous_loss) {
@@ -243,7 +245,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
                   ArrayXd next_scaled_residuals =
                       ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
                       bandwidth;
-                  next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar).sum();
+                  next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
                 }
               }
 
@@ -266,7 +268,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_m_estimator(
                   ArrayXd next_scaled_residuals =
                       ((current_xy.matrix().rowwise() - next_center).rowwise().norm().array() - next_radius) /
                       bandwidth;
-                  auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar).sum();
+                  auto next_loss = next_scaled_residuals.unaryExpr(&CircleDetection::loss_fn_scalar<double>).sum();
                   fitting_score = -1 * next_loss / bandwidth;
 
                   actual_loss_decrease = fitting_loss - next_loss;

--- a/csrc/include/CircleDetection/circle_detection_ransac.h
+++ b/csrc/include/CircleDetection/circle_detection_ransac.h
@@ -142,7 +142,7 @@ detect_circles_ransac(
 #pragma omp task
       {
         Eigen::Array<scalar_T, Eigen::Dynamic, 2> current_xy =
-            xy(seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all);
+            xy(Eigen::seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all);
         int samples_to_draw = std::min(num_samples, static_cast<int>(current_xy.rows()));
 
         std::vector<int64_t> indices(current_xy.rows());

--- a/csrc/include/CircleDetection/circle_detection_ransac.h
+++ b/csrc/include/CircleDetection/circle_detection_ransac.h
@@ -25,7 +25,7 @@ Eigen::Vector<scalar_T, 3> fit_circle_lsq(Eigen::Array<scalar_T, Eigen::Dynamic,
   xy = xy.rowwise() - origin.transpose().array();
 
   scalar_T scale = stddev(xy);
-  scale  = scale < 1e-20 ? 1.0 : scale;
+  scale = scale < 1e-20 ? 1.0 : scale;
 
   xy = xy / scale;
 

--- a/csrc/include/CircleDetection/circle_detection_ransac.h
+++ b/csrc/include/CircleDetection/circle_detection_ransac.h
@@ -12,18 +12,10 @@
 #include <vector>
 
 #include "loss_functions.h"
+#include "operations.h"
 
 #ifndef CIRCLE_DETECTION_RANSAC_H
 #define CIRCLE_DETECTION_RANSAC_H
-
-namespace {
-
-template <typename scalar_T>
-scalar_T stddev(Eigen::Array<scalar_T, Eigen::Dynamic, 2> x) {
-  scalar_T variance = (x - x.mean()).square().mean();
-  return std::sqrt(variance);
-}
-}  // namespace
 
 namespace CircleDetection {
 
@@ -33,6 +25,7 @@ Eigen::Vector<scalar_T, 3> fit_circle_lsq(Eigen::Array<scalar_T, Eigen::Dynamic,
   xy = xy.rowwise() - origin.transpose().array();
 
   scalar_T scale = stddev(xy);
+  scale  = scale < 1e-20 ? 1.0 : scale;
 
   xy = xy / scale;
 

--- a/csrc/include/CircleDetection/circle_detection_ransac.h
+++ b/csrc/include/CircleDetection/circle_detection_ransac.h
@@ -17,44 +17,44 @@
 #define CIRCLE_DETECTION_RANSAC_H
 
 namespace {
-using namespace Eigen;
-using ArrayXl = Eigen::Array<int64_t, Eigen::Dynamic, 1>;
-using ArrayXb = Eigen::Array<bool, Eigen::Dynamic, 1>;
 
-double stddev(Eigen::ArrayX2d x) {
-  double variance = (x - x.mean()).square().mean();
+template <typename scalar_T>
+scalar_T stddev(Eigen::Array<scalar_T, Eigen::Dynamic, 2> x) {
+  scalar_T variance = (x - x.mean()).square().mean();
   return std::sqrt(variance);
 }
 }  // namespace
 
 namespace CircleDetection {
 
-Vector3d fit_circle_lsq(ArrayX2d xy) {
-  Vector2d origin = xy.colwise().mean().matrix();
+template <typename scalar_T>
+Eigen::Vector<scalar_T, 3> fit_circle_lsq(Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy) {
+  Eigen::Vector<scalar_T, 2> origin = xy.colwise().mean().matrix();
   xy = xy.rowwise() - origin.transpose().array();
 
-  double scale = stddev(xy);
+  scalar_T scale = stddev(xy);
 
   xy = xy / scale;
 
-  MatrixX3d A(xy.rows(), 3);
+  Eigen::Matrix<scalar_T, Eigen::Dynamic, 3> A(xy.rows(), 3);
   A(Eigen::all, {0, 1}) = xy * 2;
-  A(Eigen::all, {2}) = ArrayXd::Constant(xy.rows(), 1.0);
-  ArrayXd f = xy.rowwise().squaredNorm();
+  A(Eigen::all, {2}) = Eigen::Array<scalar_T, Eigen::Dynamic, 1>::Constant(xy.rows(), 1.0);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> f = xy.rowwise().squaredNorm();
 
   auto qr = A.fullPivHouseholderQr();
 
   if (qr.rank() != 3) {
-    return Vector3d::Constant(3, -1);
+    return Eigen::Vector<scalar_T, 3>::Constant(3, -1);
   }
 
-  ArrayXd lsq_solution = qr.solve(f.matrix()).array();
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> lsq_solution = qr.solve(f.matrix()).array();
 
-  Vector2d center = lsq_solution({0, 1});
-  ArrayXd squared_dists = (xy.rowwise() - center.transpose().array()).rowwise().squaredNorm();
-  double radius = std::sqrt(squared_dists.mean());
+  Eigen::Vector<scalar_T, 2> center = lsq_solution({0, 1});
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> squared_dists =
+      (xy.rowwise() - center.transpose().array()).rowwise().squaredNorm();
+  scalar_T radius = std::sqrt(squared_dists.mean());
 
-  Vector3d circle;
+  Eigen::Vector<scalar_T, 3> circle;
 
   circle({0, 1}) = center;
   circle(2) = radius;
@@ -64,13 +64,16 @@ Vector3d fit_circle_lsq(ArrayX2d xy) {
   return circle;
 }
 
-std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayXl batch_lengths, ArrayXd break_min_x,
-                                                             ArrayXd break_max_x, ArrayXd break_min_y,
-                                                             ArrayXd break_max_y, ArrayXd break_min_radius,
-                                                             ArrayXd break_max_radius, double bandwidth, int iterations,
-                                                             int num_samples, int min_concensus_points = 3,
-                                                             double min_fitting_score = 1e-6, int num_workers = 1,
-                                                             int seed = -1) {
+template <typename scalar_T>
+std::tuple<Eigen::Array<scalar_T, Eigen::Dynamic, 3>, Eigen::Array<scalar_T, Eigen::Dynamic, 1>,
+           Eigen::Array<int64_t, Eigen::Dynamic, 1>>
+detect_circles_ransac(
+    Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy, Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_x, Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_x,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_y, Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_y,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_min_radius,
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> break_max_radius, scalar_T bandwidth, int iterations, int num_samples,
+    int min_concensus_points = 3, scalar_T min_fitting_score = 1e-6, int num_workers = 1, int seed = -1) {
   if (num_samples < 3) {
     throw std::invalid_argument("The required number of hypothetical inlier points must be at least 3.");
   }
@@ -108,9 +111,11 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
 
   int64_t num_batches = batch_lengths.rows();
   int64_t num_circles = num_batches * iterations;
-  ArrayX3d circles = ArrayX3d::Constant(num_circles, 3, -1);
-  ArrayXb diverged = ArrayXb::Constant(num_circles, true);
-  ArrayXd fitting_scores = ArrayXd::Constant(num_circles, -1);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles =
+      Eigen::Array<scalar_T, Eigen::Dynamic, 3>::Constant(num_circles, 3, -1);
+  Eigen::Array<bool, Eigen::Dynamic, 1> diverged = Eigen::Array<bool, Eigen::Dynamic, 1>::Constant(num_circles, true);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> fitting_scores =
+      Eigen::Array<scalar_T, Eigen::Dynamic, 1>::Constant(num_circles, -1);
   std::vector<std::mt19937> random_generators(num_batches);
 
   if (seed == -1) {
@@ -118,7 +123,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
     seed = random_device();
   }
 
-  ArrayXl batch_starts(num_batches);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_starts(num_batches);
 
   int64_t batch_start = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
@@ -136,7 +141,8 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
     for (int64_t i = 0; i < iterations; ++i) {
 #pragma omp task
       {
-        ArrayX2d current_xy = xy(seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all);
+        Eigen::Array<scalar_T, Eigen::Dynamic, 2> current_xy =
+            xy(seqN(batch_starts(batch_idx), batch_lengths(batch_idx)), Eigen::all);
         int samples_to_draw = std::min(num_samples, static_cast<int>(current_xy.rows()));
 
         std::vector<int64_t> indices(current_xy.rows());
@@ -146,9 +152,10 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
 
         std::vector<int64_t> hypothetical_inliers_indices(indices.begin(), indices.begin() + samples_to_draw);
 
-        ArrayX2d hypothetical_inliers_xy = current_xy(hypothetical_inliers_indices, Eigen::all);
+        Eigen::Array<scalar_T, Eigen::Dynamic, 2> hypothetical_inliers_xy =
+            current_xy(hypothetical_inliers_indices, Eigen::all);
 
-        Vector3d circle = fit_circle_lsq(hypothetical_inliers_xy);
+        Eigen::Vector<scalar_T, 3> circle = fit_circle_lsq<scalar_T>(hypothetical_inliers_xy);
 
         for (int step = 0; step < 1;
              ++step) {  // we use a for loop with a single iteration so that we can use break to exit early
@@ -158,7 +165,8 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
             break;
           }
           // dists to circle center
-          ArrayXd dists_to_circle = (current_xy.rowwise() - circle({0, 1}).transpose().array()).rowwise().norm();
+          Eigen::Array<scalar_T, Eigen::Dynamic, 1> dists_to_circle =
+              (current_xy.rowwise() - circle({0, 1}).transpose().array()).rowwise().norm();
           // dists to circle outline
           dists_to_circle = (dists_to_circle - circle(2)).abs();
 
@@ -171,10 +179,10 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
           if (consensus_indices.size() < min_concensus_points) {
             break;
           }
-          ArrayX2d consensus_xy = current_xy(consensus_indices, Eigen::all);
+          Eigen::Array<scalar_T, Eigen::Dynamic, 2> consensus_xy = current_xy(consensus_indices, Eigen::all);
 
           // fit circle to all consensus points
-          circle = fit_circle_lsq(consensus_xy);
+          circle = fit_circle_lsq<scalar_T>(consensus_xy);
 
           if (circle(2) == -1) {
             break;
@@ -185,8 +193,9 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
           // dists to circle outline
           dists_to_circle = (dists_to_circle - circle(2)).abs();
 
-          double fitting_score =
-              1 / bandwidth * (dists_to_circle / bandwidth).unaryExpr(&CircleDetection::score_fn_scalar).sum();
+          scalar_T fitting_score =
+              1 / bandwidth *
+              (dists_to_circle / bandwidth).unaryExpr(&CircleDetection::score_fn_scalar<scalar_T>).sum();
 
           if (fitting_score < min_fitting_score) {
             break;
@@ -203,7 +212,8 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl> detect_circles_ransac(ArrayX2d xy, ArrayX
   }
 
   std::vector<int64_t> selected_indices;
-  ArrayXl batch_lengths_circles = ArrayXl::Constant(num_batches, 0);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_circles =
+      Eigen::Array<int64_t, Eigen::Dynamic, 1>::Constant(num_batches, 0);
 
   for (int64_t i = 0; i < num_batches; ++i) {
     for (int64_t j = 0; j < iterations; ++j) {

--- a/csrc/include/CircleDetection/loss_functions.h
+++ b/csrc/include/CircleDetection/loss_functions.h
@@ -5,19 +5,25 @@
 
 namespace CircleDetection {
 
-double score_fn_scalar(double scaled_residual) {
-  const double SQRT_2_PI = 2.5066282746310002;
+template <typename scalar_T>
+scalar_T score_fn_scalar(scalar_T scaled_residual) {
+  const scalar_T SQRT_2_PI = 2.5066282746310002;
   return exp(-(scaled_residual * scaled_residual) / 2) / SQRT_2_PI;
 }
 
-double loss_fn_scalar(double scaled_residual) { return -score_fn_scalar(scaled_residual); }
-
-double loss_fn_derivative_1_scalar(double scaled_residual) {
-  return -loss_fn_scalar(scaled_residual) * scaled_residual;
+template <typename scalar_T>
+scalar_T loss_fn_scalar(scalar_T scaled_residual) {
+  return -score_fn_scalar<scalar_T>(scaled_residual);
 }
 
-double loss_fn_derivative_2_scalar(double scaled_residual) {
-  return loss_fn_scalar(scaled_residual) * (scaled_residual * scaled_residual - 1);
+template <typename scalar_T>
+scalar_T loss_fn_derivative_1_scalar(scalar_T scaled_residual) {
+  return -loss_fn_scalar<scalar_T>(scaled_residual) * scaled_residual;
+}
+
+template <typename scalar_T>
+scalar_T loss_fn_derivative_2_scalar(scalar_T scaled_residual) {
+  return loss_fn_scalar<scalar_T>(scaled_residual) * (scaled_residual * scaled_residual - 1);
 }
 }  // namespace CircleDetection
 

--- a/csrc/include/CircleDetection/operations.h
+++ b/csrc/include/CircleDetection/operations.h
@@ -14,6 +14,12 @@
 namespace CircleDetection {
 
 template <typename scalar_T>
+scalar_T stddev(Eigen::Array<scalar_T, Eigen::Dynamic, 2> x) {
+  scalar_T variance = (x - x.mean()).square().mean();
+  return std::sqrt(variance);
+}
+
+template <typename scalar_T>
 Eigen::Array<scalar_T, Eigen::Dynamic, 1> circumferential_completeness_index(
     Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles, Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy,
     Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_circles,

--- a/csrc/include/CircleDetection/operations.h
+++ b/csrc/include/CircleDetection/operations.h
@@ -94,7 +94,8 @@ Eigen::Array<scalar_T, Eigen::Dynamic, 1> circumferential_completeness_index(
             return std::atan2(y, x);
           });
 
-      Eigen::Array<int64_t, Eigen::Dynamic, 1> sections = (angles / angular_step_size).floor().cast<int64_t>();
+      Eigen::Array<int64_t, Eigen::Dynamic, 1> sections =
+          (angles / angular_step_size).floor().unaryExpr([](scalar_T x) { return static_cast<int64_t>(x); });
       sections = sections.unaryExpr([num_regions](const int64_t x) { return x % num_regions; });
 
       std::set<int64_t> filled_sections(sections.data(), sections.data() + sections.size());

--- a/csrc/include/CircleDetection/operations.h
+++ b/csrc/include/CircleDetection/operations.h
@@ -8,19 +8,17 @@
 #include <stdexcept>
 #include <vector>
 
-namespace {
-using namespace Eigen;
-using ArrayXl = Eigen::Array<int64_t, Eigen::Dynamic, 1>;
-}  // namespace
-
 #ifndef OPERATIONS_H
 #define OPERATIONS_H
 
 namespace CircleDetection {
 
-ArrayXd circumferential_completeness_index(ArrayX3d circles, ArrayX2d xy, ArrayXl batch_lengths_circles,
-                                           ArrayXl batch_lengths_xy, int64_t num_regions, double max_dist,
-                                           int num_workers = 1) {
+template <typename scalar_T>
+Eigen::Array<scalar_T, Eigen::Dynamic, 1> circumferential_completeness_index(
+    Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles, Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy,
+    Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_circles,
+    Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_xy, int64_t num_regions, scalar_T max_dist,
+    int num_workers = 1) {
   if (batch_lengths_circles.rows() != batch_lengths_xy.rows()) {
     throw std::invalid_argument("The length of batch_lengths_circles and batch_lengths_xy must be equal.");
   }
@@ -35,23 +33,23 @@ ArrayXd circumferential_completeness_index(ArrayX3d circles, ArrayX2d xy, ArrayX
     num_workers = omp_get_max_threads();
   }
 
-  constexpr double PI = 3.14159265358979311600;
+  constexpr scalar_T PI = 3.14159265358979311600;
 
   int64_t num_batches = batch_lengths_circles.size();
-  ArrayXd circumferential_completeness_indices(circles.rows());
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> circumferential_completeness_indices(circles.rows());
 
-  double angular_step_size = 2 * PI / static_cast<double>(num_regions);
+  scalar_T angular_step_size = 2 * PI / static_cast<scalar_T>(num_regions);
 
-  ArrayXl batch_starts_circles(num_batches);
-  ArrayXl batch_starts_xy(num_batches);
-  ArrayXl batch_indices(circles.rows());
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_starts_circles(num_batches);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_starts_xy(num_batches);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_indices(circles.rows());
 
   int64_t batch_start_circles = 0;
   int64_t batch_start_xy = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
     batch_starts_circles(batch_idx) = batch_start_circles;
     batch_starts_xy(batch_idx) = batch_start_xy;
-    batch_indices(seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
+    batch_indices(Eigen::seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
     batch_start_circles += batch_lengths_circles(batch_idx);
     batch_start_xy += batch_lengths_xy(batch_idx);
   }
@@ -59,11 +57,12 @@ ArrayXd circumferential_completeness_index(ArrayX3d circles, ArrayX2d xy, ArrayX
 #pragma omp parallel for default(shared) num_threads(num_workers)
   for (int64_t idx = 0; idx < circles.rows(); ++idx) {
     int64_t batch_idx = batch_indices(idx);
-    ArrayXd circle = circles(idx, Eigen::all);
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> circle = circles(idx, Eigen::all);
 
-    ArrayX2d centered_xy = xy(seqN(batch_starts_xy(batch_idx), batch_lengths_xy(batch_idx)), Eigen::all).rowwise() -
-                           circle({0, 1}).transpose();
-    ArrayXd radii = centered_xy.rowwise().norm();
+    Eigen::Array<scalar_T, Eigen::Dynamic, 2> centered_xy =
+        xy(Eigen::seqN(batch_starts_xy(batch_idx), batch_lengths_xy(batch_idx)), Eigen::all).rowwise() -
+        circle({0, 1}).transpose();
+    Eigen::Array<scalar_T, Eigen::Dynamic, 1> radii = centered_xy.rowwise().norm();
 
     if (centered_xy.rows() == 0) {
       circumferential_completeness_indices(idx) = 0.0;
@@ -82,39 +81,48 @@ ArrayXd circumferential_completeness_index(ArrayX3d circles, ArrayX2d xy, ArrayX
           }
         }
       }
-      ArrayX2d circle_xy = centered_xy(circle_xy_indices, Eigen::all);
+      Eigen::Array<scalar_T, Eigen::Dynamic, 2> circle_xy = centered_xy(circle_xy_indices, Eigen::all);
 
-      ArrayXd angles = circle_xy(Eigen::all, 1).binaryExpr(circle_xy(Eigen::all, 0), [](double y, double x) {
-        return std::atan2(y, x);
-      });
+      Eigen::Array<scalar_T, Eigen::Dynamic, 1> angles =
+          circle_xy(Eigen::all, 1).binaryExpr(circle_xy(Eigen::all, 0), [](scalar_T y, scalar_T x) {
+            return std::atan2(y, x);
+          });
 
-      ArrayXl sections = (angles / angular_step_size).floor().cast<int64_t>();
+      Eigen::Array<int64_t, Eigen::Dynamic, 1> sections = (angles / angular_step_size).floor().cast<int64_t>();
       sections = sections.unaryExpr([num_regions](const int64_t x) { return x % num_regions; });
 
       std::set<int64_t> filled_sections(sections.data(), sections.data() + sections.size());
 
-      circumferential_completeness_indices(idx) = filled_sections.size() / static_cast<double>(num_regions);
+      circumferential_completeness_indices(idx) = filled_sections.size() / static_cast<scalar_T>(num_regions);
     }
   }
 
   return circumferential_completeness_indices;
 }
 
-std::tuple<ArrayX3d, ArrayXl, ArrayXl> filter_circumferential_completeness_index(
-    ArrayX3d circles, ArrayX2d xy, ArrayXl batch_lengths_circles, ArrayXl batch_lengths_xy, int64_t num_regions,
-    double max_dist, double min_circumferential_completeness_index, int num_workers = 1) {
-  ArrayXd circumferential_completeness_indices = circumferential_completeness_index(
-      circles, xy, batch_lengths_circles, batch_lengths_xy, num_regions, max_dist, num_workers);
+template <typename scalar_T>
+std::tuple<Eigen::Array<scalar_T, Eigen::Dynamic, 3>, Eigen::Array<int64_t, Eigen::Dynamic, 1>,
+           Eigen::Array<int64_t, Eigen::Dynamic, 1>>
+filter_circumferential_completeness_index(Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles,
+                                          Eigen::Array<scalar_T, Eigen::Dynamic, 2> xy,
+                                          Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_circles,
+                                          Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths_xy,
+                                          int64_t num_regions, scalar_T max_dist,
+                                          scalar_T min_circumferential_completeness_index, int num_workers = 1) {
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> circumferential_completeness_indices =
+      circumferential_completeness_index<scalar_T>(circles, xy, batch_lengths_circles, batch_lengths_xy, num_regions,
+                                                   max_dist, num_workers);
   int64_t num_batches = batch_lengths_circles.size();
 
   std::vector<int64_t> filtered_indices = {};
-  ArrayXl filtered_batch_lengths_circles = ArrayXl::Constant(num_batches, 0);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> filtered_batch_lengths_circles =
+      Eigen::Array<int64_t, Eigen::Dynamic, 1>::Constant(num_batches, 0);
 
-  ArrayXl batch_indices(circles.rows());
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_indices(circles.rows());
 
   int64_t batch_start_circles = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
-    batch_indices(seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
+    batch_indices(Eigen::seqN(batch_start_circles, batch_lengths_circles(batch_idx))) = batch_idx;
     batch_start_circles += batch_lengths_circles(batch_idx);
   }
 
@@ -125,13 +133,18 @@ std::tuple<ArrayX3d, ArrayXl, ArrayXl> filter_circumferential_completeness_index
     }
   }
 
-  ArrayXl filtered_indices_array = Eigen::Map<ArrayXl>(filtered_indices.data(), filtered_indices.size());
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> filtered_indices_array =
+      Eigen::Map<Eigen::Array<int64_t, Eigen::Dynamic, 1>>(filtered_indices.data(), filtered_indices.size());
 
   return std::make_tuple(circles(filtered_indices, Eigen::all), filtered_batch_lengths_circles, filtered_indices_array);
 }
 
-std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d circles, ArrayXd fitting_scores,
-                                                                        ArrayXl batch_lengths, int num_workers = 1) {
+template <typename scalar_T>
+std::tuple<Eigen::Array<scalar_T, Eigen::Dynamic, 3>, Eigen::Array<scalar_T, Eigen::Dynamic, 1>,
+           Eigen::Array<int64_t, Eigen::Dynamic, 1>, Eigen::Array<int64_t, Eigen::Dynamic, 1>>
+non_maximum_suppression(Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles,
+                        Eigen::Array<scalar_T, Eigen::Dynamic, 1> fitting_scores,
+                        Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_lengths, int num_workers = 1) {
   if (circles.rows() != fitting_scores.rows()) {
     throw std::invalid_argument("circles and fitting_scores must have the same number of entries.");
   }
@@ -146,7 +159,7 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d
 
   int64_t num_batches = batch_lengths.rows();
 
-  ArrayXl batch_starts(num_batches);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> batch_starts(num_batches);
 
   int64_t batch_start = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
@@ -155,13 +168,15 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d
   }
 
   std::vector<std::vector<int64_t>> selected_indices(num_batches);
-  ArrayXl new_batch_lengths = ArrayXl::Constant(num_batches, 0);
-  ArrayXl new_batch_starts = ArrayXl::Constant(num_batches, 0);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> new_batch_lengths =
+      Eigen::Array<int64_t, Eigen::Dynamic, 1>::Constant(num_batches, 0);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> new_batch_starts =
+      Eigen::Array<int64_t, Eigen::Dynamic, 1>::Constant(num_batches, 0);
 
 #pragma omp parallel for default(shared) num_threads(num_workers)
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
     int64_t batch_start = batch_starts(batch_idx);
-    int64_t num_circles = circles(seqN(batch_start, batch_lengths(batch_idx)), Eigen::all).rows();
+    int64_t num_circles = circles(Eigen::seqN(batch_start, batch_lengths(batch_idx)), Eigen::all).rows();
     std::vector<int64_t> sorted_indices(num_circles);
     std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
     std::sort(sorted_indices.begin(), sorted_indices.end(), [&fitting_scores, batch_start](int i, int j) {
@@ -173,13 +188,13 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d
       sorted_indices.erase(sorted_indices.begin());
       selected_indices[batch_idx].push_back(batch_start + current_idx);
       new_batch_lengths(batch_idx) += 1;
-      Vector2d center(circles(batch_start + current_idx, 0), circles(batch_start + current_idx, 1));
+      Eigen::Vector2d center(circles(batch_start + current_idx, 0), circles(batch_start + current_idx, 1));
       auto radius = circles(batch_start + current_idx, 2);
 
       auto iter = sorted_indices.begin();
       while (iter < sorted_indices.end()) {
         auto other_idx = *iter;
-        Vector2d other_center(circles(batch_start + other_idx, 0), circles(batch_start + other_idx, 1));
+        Eigen::Vector2d other_center(circles(batch_start + other_idx, 0), circles(batch_start + other_idx, 1));
         auto other_radius = circles(batch_start + other_idx, 2);
 
         if ((center - other_center).norm() < radius + other_radius) {
@@ -193,9 +208,9 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d
 
   int64_t total_num_selected_circles = new_batch_lengths.sum();
 
-  ArrayX3d selected_circles(total_num_selected_circles, 3);
-  ArrayXd selected_fitting_scores(total_num_selected_circles);
-  ArrayXl selected_indices_array(total_num_selected_circles);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 3> selected_circles(total_num_selected_circles, 3);
+  Eigen::Array<scalar_T, Eigen::Dynamic, 1> selected_fitting_scores(total_num_selected_circles);
+  Eigen::Array<int64_t, Eigen::Dynamic, 1> selected_indices_array(total_num_selected_circles);
 
   batch_start = 0;
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
@@ -205,12 +220,13 @@ std::tuple<ArrayX3d, ArrayXd, ArrayXl, ArrayXl> non_maximum_suppression(ArrayX3d
 
 #pragma omp parallel for default(shared) num_threads(num_workers)
   for (int64_t batch_idx = 0; batch_idx < num_batches; ++batch_idx) {
-    selected_circles(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx)), Eigen::all) =
+    selected_circles(Eigen::seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx)), Eigen::all) =
         circles(selected_indices[batch_idx], Eigen::all);
-    selected_fitting_scores(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
+    selected_fitting_scores(Eigen::seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
         fitting_scores(selected_indices[batch_idx]);
-    selected_indices_array(seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
-        Eigen::Map<ArrayXl>(selected_indices[batch_idx].data(), new_batch_lengths(batch_idx));
+    selected_indices_array(Eigen::seqN(new_batch_starts(batch_idx), new_batch_lengths(batch_idx))) =
+        Eigen::Map<Eigen::Array<int64_t, Eigen::Dynamic, 1>>(selected_indices[batch_idx].data(),
+                                                             new_batch_lengths(batch_idx));
   }
 
   return std::make_tuple(selected_circles, selected_fitting_scores, new_batch_lengths, selected_indices_array);

--- a/csrc/include/CircleDetection/operations.h
+++ b/csrc/include/CircleDetection/operations.h
@@ -179,7 +179,7 @@ non_maximum_suppression(Eigen::Array<scalar_T, Eigen::Dynamic, 3> circles,
     int64_t num_circles = circles(Eigen::seqN(batch_start, batch_lengths(batch_idx)), Eigen::all).rows();
     std::vector<int64_t> sorted_indices(num_circles);
     std::iota(sorted_indices.begin(), sorted_indices.end(), 0);
-    std::sort(sorted_indices.begin(), sorted_indices.end(), [&fitting_scores, batch_start](int i, int j) {
+    std::sort(sorted_indices.begin(), sorted_indices.end(), [&fitting_scores, batch_start](int64_t i, int64_t j) {
       return fitting_scores(batch_start + i) > fitting_scores(batch_start + j);
     });
 

--- a/csrc/pybind/circle_detection_pybind.cpp
+++ b/csrc/pybind/circle_detection_pybind.cpp
@@ -11,7 +11,10 @@ PYBIND11_MODULE(_circle_detection_cpp, m) {
     Circle detection in 2D point sets.
   )pbdoc";
 
-  m.def("detect_circles_m_estimator", &CircleDetection::detect_circles_m_estimator,
+  m.def("detect_circles_m_estimator", &CircleDetection::detect_circles_m_estimator<float>,
+        pybind11::return_value_policy::reference_internal, "");
+
+  m.def("detect_circles_m_estimator", &CircleDetection::detect_circles_m_estimator<double>,
         pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     C++ implementation of the M-estimator-based circle detection method proposed by Tim Garlipp and Christine H.

--- a/csrc/pybind/circle_detection_pybind.cpp
+++ b/csrc/pybind/circle_detection_pybind.cpp
@@ -19,14 +19,20 @@ PYBIND11_MODULE(_circle_detection_cpp, m) {
     :code:`circle_detection.MEstimator`.
   )pbdoc");
 
-  m.def("detect_circles_ransac", &CircleDetection::detect_circles_ransac,
+  m.def("detect_circles_ransac", &CircleDetection::detect_circles_ransac<float>,
+        pybind11::return_value_policy::reference_internal, "");
+
+  m.def("detect_circles_ransac", &CircleDetection::detect_circles_ransac<double>,
         pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     C++ implementation of RANSAC circle detection that is based on least-squares circle fitting. For more details, see
     the documentation of the Python wrapper class :code:`circle_detection.Ransac`.
   )pbdoc");
 
-  m.def("fit_circle_lsq", &CircleDetection::fit_circle_lsq, pybind11::return_value_policy::reference_internal,
+  m.def("fit_circle_lsq", &CircleDetection::fit_circle_lsq<float>, pybind11::return_value_policy::reference_internal,
+        "");
+
+  m.def("fit_circle_lsq", &CircleDetection::fit_circle_lsq<double>, pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     C++ implementation of least-squares circle fitting. For more details, see the documentation of the Python wrapper
     method :code:`circle_detection.fit_circle_lsq()`.

--- a/csrc/pybind/operations_pybind.cpp
+++ b/csrc/pybind/operations_pybind.cpp
@@ -11,21 +11,31 @@ PYBIND11_MODULE(_operations_cpp,
     Post-processing operations for the circle detection.
   )pbdoc";
 
-  m.def("non_maximum_suppression", &CircleDetection::non_maximum_suppression,
+  m.def("non_maximum_suppression", &CircleDetection::non_maximum_suppression<float>,
+        pybind11::return_value_policy::reference_internal, "");
+
+  m.def("non_maximum_suppression", &CircleDetection::non_maximum_suppression<double>,
         pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     Non-maximum suppression for overlapping circles. For more details, see the documentation of the Python wrapper
     method :code:`circle_detection.operations.non_maximum_suppression()`.
   )pbdoc");
 
-  m.def("circumferential_completeness_index", &CircleDetection::circumferential_completeness_index,
+  m.def("circumferential_completeness_index", &CircleDetection::circumferential_completeness_index<float>,
+        pybind11::return_value_policy::reference_internal, "");
+
+  m.def("circumferential_completeness_index", &CircleDetection::circumferential_completeness_index<double>,
         pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     Calculates the circumferential completeness indices of the specified circles. For more details, see the documentation of the Python wrapper
     method :code:`circle_detection.operations.circumferential_completeness_index()`.
   )pbdoc");
 
-  m.def("filter_circumferential_completeness_index", &CircleDetection::filter_circumferential_completeness_index,
+  m.def("filter_circumferential_completeness_index", &CircleDetection::filter_circumferential_completeness_index<float>,
+        pybind11::return_value_policy::reference_internal, "");
+
+  m.def("filter_circumferential_completeness_index",
+        &CircleDetection::filter_circumferential_completeness_index<double>,
         pybind11::return_value_policy::reference_internal,
         R"pbdoc(
     Filters out the circles whose circumferential completeness index is below the specified minimum circumferential

--- a/src/circle_detection/_circle_detector.py
+++ b/src/circle_detection/_circle_detector.py
@@ -45,17 +45,15 @@ class CircleDetector(abc.ABC):
 
     def __init__(self) -> None:
         self._has_detected_circles = False
-        self.circles: npt.NDArray[np.float64] = np.empty((0, 3), dtype=np.float64)
-        self.fitting_scores: npt.NDArray[np.float64] = np.empty(0, dtype=np.float64)
+        self.circles: npt.NDArray = np.empty((0, 3), dtype=np.float64)
+        self.fitting_scores: npt.NDArray = np.empty(0, dtype=np.float64)
         self.batch_lengths_circles: npt.NDArray[np.int64] = np.array([0], dtype=np.int64)
 
-        self._xy: npt.NDArray[np.float64] = np.empty((0, 2), dtype=np.float64)
+        self._xy: npt.NDArray = np.empty((0, 2), dtype=np.float64)
         self._batch_lengths_xy: npt.NDArray[np.int64] = np.array([0], dtype=np.int64)
 
     @abc.abstractmethod
-    def detect(
-        self, xy: npt.NDArray[np.float64], *, batch_lengths: Optional[npt.NDArray[np.int64]] = None, **kwargs: Any
-    ):
+    def detect(self, xy: npt.NDArray, *, batch_lengths: Optional[npt.NDArray[np.int64]] = None, **kwargs: Any):
         """
         This method must be overwritten in subclasses to implement the circle detection approach.
 

--- a/src/circle_detection/_m_estimator.py
+++ b/src/circle_detection/_m_estimator.py
@@ -212,24 +212,24 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
 
     def detect(  # type: ignore[override] # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements, arguments-differ
         self,
-        xy: npt.NDArray[np.float64],
+        xy: npt.NDArray,
         *,
         batch_lengths: Optional[npt.NDArray[np.int64]] = None,
-        min_start_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        max_start_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
+        min_start_x: Optional[Union[float, npt.NDArray]] = None,
+        max_start_x: Optional[Union[float, npt.NDArray]] = None,
         n_start_x: int = 10,
-        min_start_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        max_start_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
+        min_start_y: Optional[Union[float, npt.NDArray]] = None,
+        max_start_y: Optional[Union[float, npt.NDArray]] = None,
         n_start_y: int = 10,
-        min_start_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        max_start_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
+        min_start_radius: Optional[Union[float, npt.NDArray]] = None,
+        max_start_radius: Optional[Union[float, npt.NDArray]] = None,
         n_start_radius: int = 10,
-        break_min_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_min_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_min_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
+        break_min_x: Optional[Union[float, npt.NDArray]] = None,
+        break_max_x: Optional[Union[float, npt.NDArray]] = None,
+        break_min_y: Optional[Union[float, npt.NDArray]] = None,
+        break_max_y: Optional[Union[float, npt.NDArray]] = None,
+        break_min_radius: Optional[Union[float, npt.NDArray]] = None,
+        break_max_radius: Optional[Union[float, npt.NDArray]] = None,
         num_workers: int = 1,
     ) -> None:
         r"""
@@ -392,11 +392,13 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
                     xy[batch_start:batch_end, 0].min() if batch_start < batch_end else 0
                     for (batch_start, batch_end) in zip(batch_starts, batch_ends)
                 ],
-                dtype=np.float64,
+                dtype=xy.dtype,
             )
         elif not isinstance(min_start_x, np.ndarray):
-            min_start_x = np.full(num_batches, fill_value=min_start_x, dtype=np.float64)
-        min_start_x = cast(npt.NDArray[np.float64], min_start_x)
+            min_start_x = np.full(num_batches, fill_value=min_start_x, dtype=xy.dtype)
+        else:
+            min_start_x = min_start_x.astype(xy.dtype)
+        min_start_x = cast(npt.NDArray, min_start_x)
 
         if max_start_x is None:
             max_start_x = np.array(
@@ -404,23 +406,29 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
                     xy[batch_start:batch_end, 0].max() if batch_start < batch_end else 0
                     for (batch_start, batch_end) in zip(batch_starts, batch_ends)
                 ],
-                dtype=np.float64,
+                dtype=xy.dtype,
             )
         elif not isinstance(max_start_x, np.ndarray):
-            max_start_x = np.full(num_batches, fill_value=max_start_x, dtype=np.float64)
-        max_start_x = cast(npt.NDArray[np.float64], max_start_x)
+            max_start_x = np.full(num_batches, fill_value=max_start_x, dtype=xy.dtype)
+        else:
+            max_start_x = max_start_x.astype(xy.dtype)
+        max_start_x = cast(npt.NDArray, max_start_x)
 
         if break_min_x is None:
             break_min_x = min_start_x - np.maximum(0.1 * (max_start_x - min_start_x), 2 * self._bandwidth)
         elif not isinstance(break_min_x, np.ndarray):
-            break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=np.float64)
-        break_min_x = cast(npt.NDArray[np.float64], break_min_x)
+            break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=xy.dtype)
+        else:
+            break_min_x = break_min_x.astype(xy.dtype)
+        break_min_x = cast(npt.NDArray, break_min_x)
 
         if break_max_x is None:
             break_max_x = max_start_x + np.maximum(0.1 * (max_start_x - min_start_x), 2 * self._bandwidth)
         elif not isinstance(break_max_x, np.ndarray):
-            break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=np.float64)
-        break_max_x = cast(npt.NDArray[np.float64], break_max_x)
+            break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=xy.dtype)
+        else:
+            break_max_x = break_max_x.astype(xy.dtype)
+        break_max_x = cast(npt.NDArray, break_max_x)
 
         if (min_start_x > max_start_x).any():
             raise ValueError("min_start_x must be smaller than or equal to max_start_x.")
@@ -435,11 +443,13 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
                     xy[batch_start:batch_end, 1].min() if batch_start < batch_end else 0
                     for (batch_start, batch_end) in zip(batch_starts, batch_ends)
                 ],
-                dtype=np.float64,
+                dtype=xy.dtype,
             )
         elif not isinstance(min_start_y, np.ndarray):
-            min_start_y = np.full(num_batches, fill_value=min_start_y, dtype=np.float64)
-        min_start_y = cast(npt.NDArray[np.float64], min_start_y)
+            min_start_y = np.full(num_batches, fill_value=min_start_y, dtype=xy.dtype)
+        else:
+            min_start_y = min_start_y.astype(xy.dtype)
+        min_start_y = cast(npt.NDArray, min_start_y)
 
         if max_start_y is None:
             max_start_y = np.array(
@@ -447,23 +457,29 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
                     xy[batch_start:batch_end, 1].max() if batch_start < batch_end else 0
                     for (batch_start, batch_end) in zip(batch_starts, batch_ends)
                 ],
-                dtype=np.float64,
+                dtype=xy.dtype,
             )
         elif not isinstance(max_start_y, np.ndarray):
-            max_start_y = np.full(num_batches, fill_value=max_start_y, dtype=np.float64)
-        max_start_y = cast(npt.NDArray[np.float64], max_start_y)
+            max_start_y = np.full(num_batches, fill_value=max_start_y, dtype=xy.dtype)
+        else:
+            max_start_y = max_start_y.astype(xy.dtype)
+        max_start_y = cast(npt.NDArray, max_start_y)
 
         if break_min_y is None:
             break_min_y = min_start_y - np.maximum(0.1 * (max_start_y - min_start_y), 2 * self._bandwidth)
         elif not isinstance(break_min_y, np.ndarray):
-            break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=np.float64)
-        break_min_y = cast(npt.NDArray[np.float64], break_min_y)
+            break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=xy.dtype)
+        else:
+            break_min_y = break_min_y.astype(xy.dtype)
+        break_min_y = cast(npt.NDArray, break_min_y)
 
         if break_max_y is None:
             break_max_y = max_start_y + np.maximum(0.1 * (max_start_y - min_start_y), 2 * self._bandwidth)
         elif not isinstance(break_max_y, np.ndarray):
-            break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=np.float64)
-        break_max_y = cast(npt.NDArray[np.float64], break_max_y)
+            break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=xy.dtype)
+        else:
+            break_max_y = break_max_y.astype(xy.dtype)
+        break_max_y = cast(npt.NDArray, break_max_y)
 
         if (min_start_y > max_start_y).any():
             raise ValueError("min_start_y must be smaller than or equal to max_start_y.")
@@ -484,30 +500,38 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
                 ]
             )
         elif not isinstance(max_start_radius, np.ndarray):
-            max_start_radius = np.full(num_batches, fill_value=max_start_radius, dtype=np.float64)
-        max_start_radius = cast(npt.NDArray[np.float64], max_start_radius)
+            max_start_radius = np.full(num_batches, fill_value=max_start_radius, dtype=xy.dtype)
+        else:
+            max_start_radius = max_start_radius.astype(xy.dtype)
+        max_start_radius = cast(npt.NDArray, max_start_radius)
 
         if min_start_radius is None:
             min_start_radius = 0.1 * max_start_radius  # type: ignore[assignment]
         elif not isinstance(min_start_radius, np.ndarray):
-            min_start_radius = np.full(num_batches, fill_value=min_start_radius, dtype=np.float64)
-        min_start_radius = cast(npt.NDArray[np.float64], min_start_radius)
+            min_start_radius = np.full(num_batches, fill_value=min_start_radius, dtype=xy.dtype)
+        else:
+            min_start_radius = min_start_radius.astype(xy.dtype)
+        min_start_radius = cast(npt.NDArray, min_start_radius)
 
         if break_min_radius is None:
             break_min_radius = min_start_radius - np.maximum(
                 0.1 * (max_start_radius - min_start_radius), 2 * self._bandwidth
             )
         elif not isinstance(break_min_radius, np.ndarray):
-            break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=np.float64)
-        break_min_radius = cast(npt.NDArray[np.float64], break_min_radius)
+            break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=xy.dtype)
+        else:
+            break_min_radius = break_min_radius.astype(xy.dtype)
+        break_min_radius = cast(npt.NDArray, break_min_radius)
 
         if break_max_radius is None:
             break_max_radius = max_start_radius + np.maximum(
                 0.1 * (max_start_radius - min_start_radius), 2 * self._bandwidth
             )
         elif not isinstance(break_max_radius, np.ndarray):
-            break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=np.float64)
-        break_max_radius = cast(npt.NDArray[np.float64], break_max_radius)
+            break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=xy.dtype)
+        else:
+            break_max_radius = break_max_radius.astype(xy.dtype)
+        break_max_radius = cast(npt.NDArray, break_max_radius)
 
         if (min_start_radius < 0).any():
             raise ValueError("min_start_radius must be larger than zero.")

--- a/src/circle_detection/_m_estimator.py
+++ b/src/circle_detection/_m_estimator.py
@@ -146,15 +146,15 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
         max_iterations: Maximum number of optimization iterations to run for each combination of starting values.
             Defaults to 1000.
         min_fitting_score: Minimum fitting score (equal to -1 :math:`\cdot` fitting loss) that a circle must have in
-            order not to be discarded. Defaults to :math:`100`.
+            order not to be discarded. Defaults to :math:`1`.
 
     Attributes:
         circles: After the :code:`self.detect()` method has been called, this attribute contains the parameters of the
             detected circles (in the following order: x-coordinate of the center, y-coordinate of the center, radius).
             If the :code:`self.detect()` method has not yet been called, this attribute is an empty array.
         fitting_scores: After the :code:`self.detect()` method has been called, this attribute contains the fitting
-            scores of the detected circles (negative fitting loss, higher means better). If the :code:`self.detect()`
-            method has not yet been called, this attribute is an empty array.
+            scores of the detected circles (equal to -1 :math:`\cdot` fitting loss, higher means better). If the
+            :code:`self.detect()` method has not yet been called, this attribute is an empty array.
         batch_lengths_circles: After the :code:`self.detect()` method has been called, this attribute contains the
             number of circles detected for each batch item (circles belonging to the same batch item are stored
             consecutively in :code:`self.circles`). If the :code:`self.detect()` method has not yet been
@@ -187,7 +187,7 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
         armijo_attenuation_factor: float = 0.5,
         armijo_min_decrease_percentage: float = 0.1,
         min_step_size: float = 1e-20,
-        min_fitting_score: float = 100,
+        min_fitting_score: float = 1,
     ):
         super().__init__()
 

--- a/src/circle_detection/_m_estimator.py
+++ b/src/circle_detection/_m_estimator.py
@@ -506,7 +506,7 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
         max_start_radius = cast(npt.NDArray, max_start_radius)
 
         if min_start_radius is None:
-            min_start_radius = 0.1 * max_start_radius  # type: ignore[assignment]
+            min_start_radius = 0.1 * max_start_radius
         elif not isinstance(min_start_radius, np.ndarray):
             min_start_radius = np.full(num_batches, fill_value=min_start_radius, dtype=xy.dtype)
         else:

--- a/src/circle_detection/_ransac.py
+++ b/src/circle_detection/_ransac.py
@@ -217,13 +217,13 @@ class Ransac(CircleDetector):
         )
 
         if break_min_x is None:
-            break_min_x = min_start_x - 2 * self._bandwidth  # type: ignore[assignment]
+            break_min_x = min_start_x - 2 * self._bandwidth
         elif not isinstance(break_min_x, np.ndarray):
             break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=xy.dtype)
         break_min_x = cast(npt.NDArray, break_min_x)
 
         if break_max_x is None:
-            break_max_x = max_start_x + 2 * self._bandwidth  # type: ignore[assignment]
+            break_max_x = max_start_x + 2 * self._bandwidth
         elif not isinstance(break_max_x, np.ndarray):
             break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=xy.dtype)
         break_max_x = cast(npt.NDArray, break_max_x)
@@ -248,13 +248,13 @@ class Ransac(CircleDetector):
         )
 
         if break_min_y is None:
-            break_min_y = min_start_y - 2 * self._bandwidth  # type: ignore[assignment]
+            break_min_y = min_start_y - 2 * self._bandwidth
         elif not isinstance(break_min_y, np.ndarray):
             break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=xy.dtype)
         break_min_y = cast(npt.NDArray, break_min_y)
 
         if break_max_y is None:
-            break_max_y = max_start_y + 2 * self._bandwidth  # type: ignore[assignment]
+            break_max_y = max_start_y + 2 * self._bandwidth
         elif not isinstance(break_max_y, np.ndarray):
             break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=xy.dtype)
         break_max_y = cast(npt.NDArray, break_max_y)
@@ -280,7 +280,7 @@ class Ransac(CircleDetector):
         break_min_radius = cast(npt.NDArray, break_min_radius)
 
         if break_max_radius is None:
-            break_max_radius = max_start_radius + 2 * self._bandwidth  # type: ignore[assignment]
+            break_max_radius = max_start_radius + 2 * self._bandwidth
         elif not isinstance(break_max_radius, np.ndarray):
             break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=xy.dtype)
         break_max_radius = cast(npt.NDArray, break_max_radius)

--- a/src/circle_detection/_ransac.py
+++ b/src/circle_detection/_ransac.py
@@ -114,20 +114,19 @@ class Ransac(CircleDetector):
 
     def detect(  # type: ignore[override] # pylint: disable=arguments-differ, too-many-arguments, too-many-locals, too-many-branches, too-many-statements
         self,
-        xy: npt.NDArray[np.float64],
+        xy: npt.NDArray,
         *,
         batch_lengths: Optional[npt.NDArray[np.int64]] = None,
-        break_min_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_x: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_min_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_y: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_min_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
-        break_max_radius: Optional[Union[float, npt.NDArray[np.float64]]] = None,
+        break_min_x: Optional[Union[float, npt.NDArray]] = None,
+        break_max_x: Optional[Union[float, npt.NDArray]] = None,
+        break_min_y: Optional[Union[float, npt.NDArray]] = None,
+        break_max_y: Optional[Union[float, npt.NDArray]] = None,
+        break_min_radius: Optional[Union[float, npt.NDArray]] = None,
+        break_max_radius: Optional[Union[float, npt.NDArray]] = None,
         num_workers: int = 1,
         seed: Optional[int] = None,
     ):
         """
-
         Executes the circle detection on the given input points. The results of the circle detection are stored in
         :code:`self.circles`, :code:`self.fitting_scores`, and :code:`self.batch_lengths_circles`.
 
@@ -206,7 +205,7 @@ class Ransac(CircleDetector):
                 xy[batch_start:batch_end, 0].min() if batch_start < batch_end else 0
                 for (batch_start, batch_end) in zip(batch_starts, batch_ends)
             ],
-            dtype=np.float64,
+            dtype=xy.dtype,
         )
 
         max_start_x = np.array(
@@ -214,20 +213,20 @@ class Ransac(CircleDetector):
                 xy[batch_start:batch_end, 0].max() if batch_start < batch_end else 0
                 for (batch_start, batch_end) in zip(batch_starts, batch_ends)
             ],
-            dtype=np.float64,
+            dtype=xy.dtype,
         )
 
         if break_min_x is None:
             break_min_x = min_start_x - 2 * self._bandwidth  # type: ignore[assignment]
         elif not isinstance(break_min_x, np.ndarray):
-            break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=np.float64)
-        break_min_x = cast(npt.NDArray[np.float64], break_min_x)
+            break_min_x = np.full(num_batches, fill_value=break_min_x, dtype=xy.dtype)
+        break_min_x = cast(npt.NDArray, break_min_x)
 
         if break_max_x is None:
             break_max_x = max_start_x + 2 * self._bandwidth  # type: ignore[assignment]
         elif not isinstance(break_max_x, np.ndarray):
-            break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=np.float64)
-        break_max_x = cast(npt.NDArray[np.float64], break_max_x)
+            break_max_x = np.full(num_batches, fill_value=break_max_x, dtype=xy.dtype)
+        break_max_x = cast(npt.NDArray, break_max_x)
 
         if (break_min_x >= break_max_x).any():
             raise ValueError("break_min_x must be smaller than break_max_x.")
@@ -237,7 +236,7 @@ class Ransac(CircleDetector):
                 xy[batch_start:batch_end, 1].min() if batch_start < batch_end else 0
                 for (batch_start, batch_end) in zip(batch_starts, batch_ends)
             ],
-            dtype=np.float64,
+            dtype=xy.dtype,
         )
 
         max_start_y = np.array(
@@ -245,20 +244,20 @@ class Ransac(CircleDetector):
                 xy[batch_start:batch_end, 1].max() if batch_start < batch_end else 0
                 for (batch_start, batch_end) in zip(batch_starts, batch_ends)
             ],
-            dtype=np.float64,
+            dtype=xy.dtype,
         )
 
         if break_min_y is None:
             break_min_y = min_start_y - 2 * self._bandwidth  # type: ignore[assignment]
         elif not isinstance(break_min_y, np.ndarray):
-            break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=np.float64)
-        break_min_y = cast(npt.NDArray[np.float64], break_min_y)
+            break_min_y = np.full(num_batches, fill_value=break_min_y, dtype=xy.dtype)
+        break_min_y = cast(npt.NDArray, break_min_y)
 
         if break_max_y is None:
             break_max_y = max_start_y + 2 * self._bandwidth  # type: ignore[assignment]
         elif not isinstance(break_max_y, np.ndarray):
-            break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=np.float64)
-        break_max_y = cast(npt.NDArray[np.float64], break_max_y)
+            break_max_y = np.full(num_batches, fill_value=break_max_y, dtype=xy.dtype)
+        break_max_y = cast(npt.NDArray, break_max_y)
 
         if (break_min_y > break_max_y).any():
             raise ValueError("break_min_y must be smaller than break_max_y.")
@@ -275,16 +274,16 @@ class Ransac(CircleDetector):
         )
 
         if break_min_radius is None:
-            break_min_radius = np.zeros(num_batches, dtype=np.float64)
+            break_min_radius = np.zeros(num_batches, dtype=xy.dtype)
         elif not isinstance(break_min_radius, np.ndarray):
-            break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=np.float64)
-        break_min_radius = cast(npt.NDArray[np.float64], break_min_radius)
+            break_min_radius = np.full(num_batches, fill_value=break_min_radius, dtype=xy.dtype)
+        break_min_radius = cast(npt.NDArray, break_min_radius)
 
         if break_max_radius is None:
             break_max_radius = max_start_radius + 2 * self._bandwidth  # type: ignore[assignment]
         elif not isinstance(break_max_radius, np.ndarray):
-            break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=np.float64)
-        break_max_radius = cast(npt.NDArray[np.float64], break_max_radius)
+            break_max_radius = np.full(num_batches, fill_value=break_max_radius, dtype=xy.dtype)
+        break_max_radius = cast(npt.NDArray, break_max_radius)
 
         if (break_min_radius > break_max_radius).any():
             raise ValueError("break_min_radius must be smaller than break_max_radius.")

--- a/src/circle_detection/operations/_circumferential_completeness_index.py
+++ b/src/circle_detection/operations/_circumferential_completeness_index.py
@@ -17,14 +17,14 @@ from circle_detection.operations._operations_cpp import (  # type: ignore[import
 
 
 def circumferential_completeness_index(
-    circles: npt.NDArray[np.float64],
-    xy: npt.NDArray[np.float64],
+    circles: npt.NDArray,
+    xy: npt.NDArray,
     num_regions: int,
     max_dist: Optional[float] = None,
     batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
     batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
     num_workers: int = 1,
-) -> npt.NDArray[np.float64]:
+) -> npt.NDArray:
     r"""
     Calculates the circumferential completeness indices of the specified circles. The circumferential completeness index
     is a metric that measures how well a circle fitted to a set of points is covered by points. It was proposed in
@@ -102,15 +102,15 @@ def circumferential_completeness_index(
 
 
 def filter_circumferential_completeness_index(
-    circles: npt.NDArray[np.float64],
-    xy: npt.NDArray[np.float64],
+    circles: npt.NDArray,
+    xy: npt.NDArray,
     num_regions: int,
     min_circumferential_completeness_index: float,
     max_dist: Optional[float] = None,
     batch_lengths_circles: Optional[npt.NDArray[np.int64]] = None,
     batch_lengths_xy: Optional[npt.NDArray[np.int64]] = None,
     num_workers: int = 1,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+) -> Tuple[npt.NDArray, npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Filters out the circles whose circumferential completeness index is below the specified minimum circumferential
     completeness index. This method supports batch processing, i.e. separate sets of circles (i.e., different batch

--- a/src/circle_detection/operations/_deduplicate_circles.py
+++ b/src/circle_detection/operations/_deduplicate_circles.py
@@ -9,10 +9,10 @@ import numpy.typing as npt
 
 
 def deduplicate_circles(
-    circles: npt.NDArray[np.float64],
+    circles: npt.NDArray,
     deduplication_precision: int,
     batch_lengths: Optional[npt.NDArray[np.int64]] = None,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+) -> Tuple[npt.NDArray, npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Deduplicates circles whose parameters do not differ up to the decimal place specified by
     :code:`deduplication_precision`. This method supports batch processing, i.e. separate sets of
@@ -67,8 +67,8 @@ def deduplicate_circles(
         return circles[selected_indices], np.array([len(unique_rounded_circles)], dtype=np.int64), selected_indices
 
     # add batch indices as first dimension to separate circles from different batch items
-    rounded_circles = np.empty((len(circles), 4), dtype=np.float64)
-    rounded_circles[:, 0] = np.repeat(np.arange(len(batch_lengths), dtype=np.float64), batch_lengths)
+    rounded_circles = np.empty((len(circles), 4), dtype=circles.dtype)
+    rounded_circles[:, 0] = np.repeat(np.arange(len(batch_lengths), dtype=circles.dtype), batch_lengths)
     rounded_circles[:, 1:] = np.round(circles, decimals=deduplication_precision)
 
     unique_rounded_circles, selected_indices = np.unique(rounded_circles, return_index=True, axis=0)

--- a/src/circle_detection/operations/_non_maximum_suppression.py
+++ b/src/circle_detection/operations/_non_maximum_suppression.py
@@ -13,11 +13,11 @@ from circle_detection.operations._operations_cpp import (  # type: ignore[import
 
 
 def non_maximum_suppression(
-    circles: npt.NDArray[np.float64],
-    fitting_scores: npt.NDArray[np.float64],
+    circles: npt.NDArray,
+    fitting_scores: npt.NDArray,
     batch_lengths: Optional[npt.NDArray[np.int64]] = None,
     num_workers: int = 1,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Non-maximum suppression operation to remove overlapping circles. If a circle overlaps with other circles, it is
     only kept if it has the highest fitting score among the circles with which it overlaps. This method supports batch

--- a/src/circle_detection/operations/_select_top_k_circles.py
+++ b/src/circle_detection/operations/_select_top_k_circles.py
@@ -9,11 +9,11 @@ import numpy.typing as npt
 
 
 def select_top_k_circles(
-    circles: npt.NDArray[np.float64],
-    fitting_scores: npt.NDArray[np.float64],
+    circles: npt.NDArray,
+    fitting_scores: npt.NDArray,
     k: int,
     batch_lengths: Optional[npt.NDArray[np.int64]] = None,
-) -> Tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.int64], npt.NDArray[np.int64]]:
+) -> Tuple[npt.NDArray, npt.NDArray, npt.NDArray[np.int64], npt.NDArray[np.int64]]:
     r"""
     Selects the :code:`k` circles with the highest fitting scores from a set of circles. If the set of circles contains
     less than :code:`k` circles, all circles are kept. This method supports batch processing, i.e. separate sets of
@@ -69,7 +69,7 @@ def select_top_k_circles(
 
         return circles[sorting_indices][:k], fitting_scores[sorting_indices][:k], batch_lengths, selected_indices
 
-    batch_indices = np.repeat(np.arange(len(batch_lengths), dtype=np.float64), batch_lengths)
+    batch_indices = np.repeat(np.arange(len(batch_lengths), dtype=circles.dtype), batch_lengths)
     sorting_indices = np.lexsort((-1 * fitting_scores, batch_indices))
     selected_indices = np.cumsum(np.concatenate(([0], batch_lengths)))[:-1]
 

--- a/test/operations/test_circumferential_completeness_index.py
+++ b/test/operations/test_circumferential_completeness_index.py
@@ -15,9 +15,12 @@ class TestCircumferentialCompletenessIndex:  # pylint: disable=too-few-public-me
 
     @pytest.mark.parametrize("pass_batch_lengths", [True, False])
     @pytest.mark.parametrize("max_dist", [0.1, None])
-    def test_circumferential_completeness_index(self, pass_batch_lengths: bool, max_dist: Optional[float]):
-        circles = np.array([[0, 0, 1], [5, 0, 1]], dtype=np.float64)
-        xy = np.array([[0, 1], [0, -1], [1, 0], [-1, 0], [5, 1], [5, -1]], dtype=np.float64)
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_circumferential_completeness_index(
+        self, pass_batch_lengths: bool, max_dist: Optional[float], scalar_dtype: np.dtype
+    ):
+        circles = np.array([[0, 0, 1], [5, 0, 1]], dtype=scalar_dtype)
+        xy = np.array([[0, 1], [0, -1], [1, 0], [-1, 0], [5, 1], [5, -1]], dtype=scalar_dtype)
 
         if pass_batch_lengths:
             batch_lengths_circles = np.array([len(circles)], dtype=np.int64)
@@ -28,12 +31,13 @@ class TestCircumferentialCompletenessIndex:  # pylint: disable=too-few-public-me
 
         num_regions = 4
 
-        expected_circumferential_completness_indices = np.array([1, 0.5], dtype=np.float64)
+        expected_circumferential_completness_indices = np.array([1, 0.5], dtype=scalar_dtype)
 
         circumferential_completeness_indices = circumferential_completeness_index(
             circles, xy, num_regions, max_dist, batch_lengths_circles, batch_lengths_xy
         )
 
+        assert circumferential_completeness_indices.dtype == scalar_dtype
         np.testing.assert_array_equal(
             expected_circumferential_completness_indices, circumferential_completeness_indices
         )
@@ -51,6 +55,7 @@ class TestCircumferentialCompletenessIndex:  # pylint: disable=too-few-public-me
             batch_lengths_xy=batch_lengths_xy,
         )
 
+        assert filtered_circles.dtype == scalar_dtype
         np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
         np.testing.assert_array_equal(expected_batch_lengths_circles, batch_lengths_circles)
         np.testing.assert_array_equal(filtered_circles, circles[selected_indices])

--- a/test/operations/test_non_maximum_suppression.py
+++ b/test/operations/test_non_maximum_suppression.py
@@ -13,33 +13,39 @@ class TestNonMaximumSuppression:
     """Tests for :code:`circle_detection.operations.non_maximum_suppression`."""
 
     @pytest.mark.parametrize("pass_batch_lengths", [True, False])
-    def test_non_overlapping_circles(self, pass_batch_lengths: bool):
-        circles = np.array([[0, 0, 1], [3, 0, 0.5], [0, 2, 0.1]], dtype=np.float64)
-        fitting_scores = np.zeros(3, dtype=np.float64)
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_non_overlapping_circles(self, pass_batch_lengths: bool, scalar_dtype: np.dtype):
+        circles = np.array([[0, 0, 1], [3, 0, 0.5], [0, 2, 0.1]], dtype=scalar_dtype)
+        fitting_scores = np.zeros(3, dtype=scalar_dtype)
         batch_lengths = np.array([3], dtype=np.int64)
 
         filtered_circles, filtered_fitting_scores, filtered_batch_lengths, selected_indices = non_maximum_suppression(
             circles, fitting_scores, batch_lengths if pass_batch_lengths else None
         )
 
+        assert filtered_circles.dtype == scalar_dtype
+        assert filtered_fitting_scores.dtype == scalar_dtype
         np.testing.assert_array_equal(circles, filtered_circles)
         np.testing.assert_array_equal(fitting_scores, filtered_fitting_scores)
         np.testing.assert_array_equal(batch_lengths, filtered_batch_lengths)
         np.testing.assert_array_equal(filtered_circles, circles[selected_indices])
 
-    def test_overlapping_circles(self):
-        circles = np.array([[0, 0, 1], [0.9, 0.1, 1], [0, 2, 0.1]], dtype=np.float64)
-        fitting_scores = np.array([1, 2, 3], dtype=np.float64)
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_overlapping_circles(self, scalar_dtype: np.dtype):
+        circles = np.array([[0, 0, 1], [0.9, 0.1, 1], [0, 2, 0.1]], dtype=scalar_dtype)
+        fitting_scores = np.array([1, 2, 3], dtype=scalar_dtype)
         batch_lengths = np.array([len(circles)], dtype=np.int64)
 
-        expected_filtered_circles = np.array([[0, 2, 0.1], [0.9, 0.1, 1]], dtype=np.float64)
-        expected_filtered_fitting_scores = np.array([3, 2], dtype=np.float64)
+        expected_filtered_circles = np.array([[0, 2, 0.1], [0.9, 0.1, 1]], dtype=scalar_dtype)
+        expected_filtered_fitting_scores = np.array([3, 2], dtype=scalar_dtype)
         expected_filtered_batch_lengths = np.array([len(expected_filtered_circles)], dtype=np.int64)
 
         filtered_circles, filtered_fitting_scores, filtered_batch_lengths, selected_indices = non_maximum_suppression(
             circles, fitting_scores, batch_lengths
         )
 
+        assert filtered_circles.dtype == scalar_dtype
+        assert filtered_fitting_scores.dtype == scalar_dtype
         np.testing.assert_array_equal(expected_filtered_circles, filtered_circles)
         np.testing.assert_array_equal(expected_filtered_fitting_scores, filtered_fitting_scores)
         np.testing.assert_array_equal(expected_filtered_batch_lengths, filtered_batch_lengths)

--- a/test/operations/test_select_top_k_circles.py
+++ b/test/operations/test_select_top_k_circles.py
@@ -10,15 +10,16 @@ class TestSelectTopKCircles:
     """Tests for :code:`circle_detection.operations.select_top_k_circles`."""
 
     @pytest.mark.parametrize("pass_batch_lengths", [True, False])
-    def test_single_batch_item(self, pass_batch_lengths: bool):
-        circles = np.array([[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8]], dtype=np.float64)
-        fitting_scores = np.array([1, 3, 2])
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_single_batch_item(self, pass_batch_lengths: bool, scalar_dtype: np.dtype):
+        circles = np.array([[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8]], dtype=scalar_dtype)
+        fitting_scores = np.array([1, 3, 2], dtype=scalar_dtype)
         batch_lengths = None
         if pass_batch_lengths:
             batch_lengths = np.array([3], dtype=np.int64)
 
-        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8]])
-        expected_fitting_scores = np.array([3, 2])
+        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8]], dtype=scalar_dtype)
+        expected_fitting_scores = np.array([3, 2], dtype=scalar_dtype)
         expected_batch_lengths = np.array([2])
         expected_selected_indices = np.array([1, 2])
 
@@ -26,6 +27,9 @@ class TestSelectTopKCircles:
         selected_circles, selected_fitting_scores, selected_batch_lengths, selected_indices = select_top_k_circles(
             circles, fitting_scores, k=k, batch_lengths=batch_lengths
         )
+
+        assert selected_circles.dtype == scalar_dtype
+        assert selected_fitting_scores.dtype == scalar_dtype
 
         np.testing.assert_array_equal(expected_circles, selected_circles)
         np.testing.assert_array_equal(expected_fitting_scores, selected_fitting_scores)
@@ -36,11 +40,11 @@ class TestSelectTopKCircles:
         circles = np.array(
             [[0, 0, 1], [0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6], [0, 0, 0.5]], dtype=np.float64
         )
-        fitting_scores = np.array([1, 3, 2, 1, 2, 1])
+        fitting_scores = np.array([1, 3, 2, 1, 2, 1], dtype=np.float64)
         batch_lengths = np.array([3, 2, 1], dtype=np.int64)
 
-        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6], [0, 0, 0.5]])
-        expected_fitting_scores = np.array([3, 2, 1, 2, 1])
+        expected_circles = np.array([[0, 0, 0.9], [0, 0, 0.8], [0, 0, 0.7], [0, 0, 0.6], [0, 0, 0.5]], dtype=np.float64)
+        expected_fitting_scores = np.array([3, 2, 1, 2, 1], dtype=np.float64)
         expected_batch_lengths = np.array([2, 2, 1])
         expected_selected_indices = np.array([1, 2, 3, 4, 5])
 

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -33,7 +33,7 @@ class TestMEstimator:
         np.testing.assert_array_equal(circle_detector.batch_lengths_circles, np.array([1], dtype=np.int64))
 
         # the first circle is expected to be returned because its points have lower variance
-        decimal = 10 if scalar_dtype == np.float64 else 7
+        decimal = 10 if scalar_dtype == np.float64 else 5
         np.testing.assert_almost_equal(original_circles[0], circle_detector.circles[0], decimal=decimal)
 
         circle_detector.detect(xy, num_workers=-1)
@@ -49,7 +49,7 @@ class TestMEstimator:
         for circle in circle_detector.circles:
             residuals = (np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth
             expected_loss = 1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2) / bandwidth
-            expected_fitting_scores.append(expected_loss.sum())
+            expected_fitting_scores.append(expected_loss.mean())
 
         assert (np.abs(original_circles - circle_detector.circles) < 0.01).all()
         decimal = 10 if scalar_dtype == np.float64 else 4
@@ -70,7 +70,7 @@ class TestMEstimator:
         min_start_xy = xy.min(axis=0) - 2
         max_start_xy = xy.max(axis=0) + 2
 
-        circle_detector = MEstimator(bandwidth=0.05, min_fitting_score=100)
+        circle_detector = MEstimator(bandwidth=0.05, min_fitting_score=1)
         circle_detector.detect(
             xy,
             min_start_x=min_start_xy[0],

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -9,7 +9,7 @@ import pytest
 
 from circle_detection import MEstimator
 
-from test.utils import generate_circles, generate_circle_points
+from test.utils import generate_circles, generate_circle_points  # pylint: disable=wrong-import-order
 
 
 class TestMEstimator:

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -9,7 +9,7 @@ import pytest
 
 from circle_detection import MEstimator
 
-from .utils import generate_circles, generate_circle_points
+from test.utils import generate_circles, generate_circle_points
 
 
 class TestMEstimator:
@@ -33,7 +33,7 @@ class TestMEstimator:
         np.testing.assert_array_equal(circle_detector.batch_lengths_circles, np.array([1], dtype=np.int64))
 
         # the first circle is expected to be returned because its points have lower variance
-        decimal = 10 if scalar_dtype == np.float64 else 5
+        decimal = 10 if scalar_dtype == np.float64 else 7
         np.testing.assert_almost_equal(original_circles[0], circle_detector.circles[0], decimal=decimal)
 
         circle_detector.detect(xy, num_workers=-1)
@@ -52,7 +52,7 @@ class TestMEstimator:
             expected_fitting_scores.append(expected_loss.sum())
 
         assert (np.abs(original_circles - circle_detector.circles) < 0.01).all()
-        decimal = 5 if scalar_dtype == np.float64 else 4
+        decimal = 10 if scalar_dtype == np.float64 else 4
         np.testing.assert_almost_equal(expected_fitting_scores, circle_detector.fitting_scores, decimal=decimal)
 
     @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -15,9 +15,11 @@ from .utils import generate_circles, generate_circle_points
 class TestMEstimator:
     """Tests for :code:`circle_detection.MEstimator`."""
 
-    def test_circle_one_perfect_fit_and_one_noisy_circle(self):
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_circle_one_perfect_fit_and_one_noisy_circle(self, scalar_dtype: np.dtype):
         original_circles = np.array([[0, 0, 0.5], [0, 2, 0.5]])
         xy = generate_circle_points(original_circles, min_points=100, max_points=100, variance=np.array([0, 0.05]))
+        xy = xy.astype(scalar_dtype)
         bandwidth = 0.07
 
         circle_detector = MEstimator(bandwidth=bandwidth)
@@ -26,16 +28,21 @@ class TestMEstimator:
 
         assert len(circle_detector.circles) == 1
         assert len(circle_detector.fitting_scores) == 1
+        assert circle_detector.circles.dtype == scalar_dtype
+        assert circle_detector.fitting_scores.dtype == scalar_dtype
         np.testing.assert_array_equal(circle_detector.batch_lengths_circles, np.array([1], dtype=np.int64))
 
         # the first circle is expected to be returned because its points have lower variance
-        np.testing.assert_almost_equal(original_circles[0], circle_detector.circles[0], decimal=10)
+        decimal = 10 if scalar_dtype == np.float64 else 5
+        np.testing.assert_almost_equal(original_circles[0], circle_detector.circles[0], decimal=decimal)
 
         circle_detector.detect(xy, num_workers=-1)
         circle_detector.filter(max_circles=2, non_maximum_suppression=True, num_workers=-1)
 
         assert len(circle_detector.circles) == 2
         assert len(circle_detector.fitting_scores) == 2
+        assert circle_detector.circles.dtype == scalar_dtype
+        assert circle_detector.fitting_scores.dtype == scalar_dtype
         np.testing.assert_array_equal(circle_detector.batch_lengths_circles, np.array([2], dtype=np.int64))
 
         expected_fitting_scores = []
@@ -45,9 +52,11 @@ class TestMEstimator:
             expected_fitting_scores.append(expected_loss.sum())
 
         assert (np.abs(original_circles - circle_detector.circles) < 0.01).all()
-        np.testing.assert_almost_equal(expected_fitting_scores, circle_detector.fitting_scores, decimal=5)
+        decimal = 5 if scalar_dtype == np.float64 else 4
+        np.testing.assert_almost_equal(expected_fitting_scores, circle_detector.fitting_scores, decimal=decimal)
 
-    def test_several_noisy_circles(self):
+    @pytest.mark.parametrize("scalar_dtype", [np.float32, np.float64])
+    def test_several_noisy_circles(self, scalar_dtype: np.dtype):
         original_circles = generate_circles(
             num_circles=2,
             min_radius=0.2,
@@ -56,6 +65,7 @@ class TestMEstimator:
         xy = generate_circle_points(
             original_circles, min_points=50, max_points=150, add_noise_points=True, variance=0.01
         )
+        xy = xy.astype(scalar_dtype)
 
         min_start_xy = xy.min(axis=0) - 2
         max_start_xy = xy.max(axis=0) + 2
@@ -84,6 +94,8 @@ class TestMEstimator:
 
         assert len(original_circles) == len(circle_detector.circles)
         assert len(circle_detector.circles) == len(circle_detector.fitting_scores)
+        assert circle_detector.circles.dtype == scalar_dtype
+        assert circle_detector.fitting_scores.dtype == scalar_dtype
         np.testing.assert_array_equal(
             circle_detector.batch_lengths_circles, np.array([len(original_circles)], dtype=np.int64)
         )


### PR DESCRIPTION
This pull request adapts the circle detectors to support input arrays of different floating point types. Previously, only arrays of type `numpy.float64` were supported.

BREAKING CHANGE:

Reverts #7: To improve numerical stability, the fitting loss now uses a mean instead of a sum again.