### PR TITLE
refactor: fitting score of M-estimator

### DIFF
--- a/csrc/include/CircleDetection/circle_detection_ransac.h
+++ b/csrc/include/CircleDetection/circle_detection_ransac.h
@@ -195,7 +195,7 @@ std::tuple<ArrayX3<scalar_T>, ArrayX<scalar_T>, ArrayXl> detect_circles_ransac(
           // dists to circle center
           dists_to_circle = (xy_per_batch[batch_idx].rowwise() - circle({0, 1}).transpose().array()).rowwise().norm();
           // dists to circle outline
-          dists_to_circle = (dists_to_circle - circle(2)).abs();
+          dists_to_circle = dists_to_circle - circle(2);
 
           scalar_T fitting_score =
               1 / bandwidth *

--- a/src/circle_detection/_m_estimator.py
+++ b/src/circle_detection/_m_estimator.py
@@ -136,7 +136,7 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
         max_iterations: Maximum number of optimization iterations to run for each combination of starting values.
             Defaults to 1000.
         min_fitting_score: Minimum fitting score (equal to -1 :math:`\cdot` fitting loss) that a circle must have in
-            order not to be discarded. Defaults to :math:`1`.
+            order not to be discarded. Defaults to :math:`100`.
 
     Attributes:
         circles: After the :code:`self.detect()` method has been called, this attribute contains the parameters of the
@@ -177,7 +177,7 @@ class MEstimator(CircleDetector):  # pylint: disable=too-many-instance-attribute
         armijo_attenuation_factor: float = 0.5,
         armijo_min_decrease_percentage: float = 0.1,
         min_step_size: float = 1e-20,
-        min_fitting_score: float = 1,
+        min_fitting_score: float = 100,
     ):
         super().__init__()
 

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -49,9 +49,9 @@ class TestMEstimator:
 
         expected_fitting_scores = []
         for circle in circle_detector.circles:
-            residuals = (np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth
-            expected_loss = 1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2) / bandwidth
-            expected_fitting_scores.append(expected_loss.mean())
+            residuals = ((np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth)
+            expected_fitting_score = 1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2) / bandwidth
+            expected_fitting_scores.append(expected_fitting_score.sum())
 
         assert (np.abs(original_circles - circle_detector.circles) < 0.01).all()
         decimal = 10 if scalar_dtype == np.float64 else 4
@@ -72,7 +72,7 @@ class TestMEstimator:
         min_start_xy = xy.min(axis=0) - 2
         max_start_xy = xy.max(axis=0) + 2
 
-        circle_detector = MEstimator(bandwidth=0.05, min_fitting_score=1)
+        circle_detector = MEstimator(bandwidth=0.05, min_fitting_score=100)
         circle_detector.detect(
             xy,
             min_start_x=min_start_xy[0],

--- a/test/test_m_estimator.py
+++ b/test/test_m_estimator.py
@@ -49,7 +49,7 @@ class TestMEstimator:
 
         expected_fitting_scores = []
         for circle in circle_detector.circles:
-            residuals = ((np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth)
+            residuals = (np.linalg.norm(xy - circle[:2], axis=-1) - circle[2]) / bandwidth
             expected_fitting_score = 1 / np.sqrt(2 * np.pi) * np.exp(-1 / 2 * residuals**2) / bandwidth
             expected_fitting_scores.append(expected_fitting_score.sum())
 


### PR DESCRIPTION
BREAKING CHANGE: This pull request refactors the fitting score computation of the M-estimator circle detector. As originally introduced in #7, the fitting score now uses a sum over the scores of all points instead of a mean: In this way, the fitting score of a point can indicate how many points a circle covers, and the fitting score of a circle becomes independent of the number of noise points in the input set. In #24, the sum was replaced by a mean to increase numeric stability. This issue has now been resolved by separating the computation of the fitting loss (using the mean) and the fitting score (using the sum).